### PR TITLE
Add drag & drop support for CSV upload

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,9 @@
 const input = document.getElementById('input-file')
+const dropZone = document.getElementById('drop-zone')
 const handsontableContainer = document.getElementById('handsontable-container')
 
-input.onchange = function () {
-  const file = this.files[0]
+function loadFile(file) {
+  if (!file) return
   const reader = new FileReader()
 
   reader.onload = function (e) {
@@ -15,7 +16,7 @@ input.onchange = function () {
     // reset container
     handsontableContainer.innerHTML = ''
     handsontableContainer.className = ''
-    document.querySelector('input').remove()
+    dropZone.remove()
     document.querySelector('.sponsors').remove()
 
     Handsontable(handsontableContainer, {
@@ -28,5 +29,38 @@ input.onchange = function () {
     })
   }
 
-  file && reader.readAsText(file)
+  reader.readAsText(file)
 }
+
+// Click-to-browse
+input.onchange = function () {
+  loadFile(this.files[0])
+}
+
+// Drag-and-drop — listen on the whole window so any drop position works
+let dragCounter = 0
+
+window.addEventListener('dragenter', (e) => {
+  e.preventDefault()
+  dragCounter++
+  dropZone.classList.add('drag-over')
+})
+
+window.addEventListener('dragleave', () => {
+  dragCounter--
+  if (dragCounter === 0) dropZone.classList.remove('drag-over')
+})
+
+window.addEventListener('dragover', (e) => {
+  e.preventDefault()
+})
+
+window.addEventListener('drop', (e) => {
+  e.preventDefault()
+  dragCounter = 0
+  dropZone.classList.remove('drag-over')
+  const file = e.dataTransfer.files[0]
+  if (file && file.name.endsWith('.csv')) {
+    loadFile(file)
+  }
+})

--- a/app.js
+++ b/app.js
@@ -56,13 +56,20 @@ window.addEventListener('dragleave', (e) => {
   if (!isFileDrag(e)) return
   dragCounter--
   if (dragCounter === 0) dropZone.classList.remove('drag-over')
+  if (dragCounter <= 0) {
+    dragCounter = 0
+    dropZone.classList.remove('drag-over')
+  }
 })
 
 window.addEventListener('dragover', (e) => {
-  if (!isFileDrag(e)) return
   e.preventDefault()
 })
 
+window.addEventListener('dragend', () => {
+  dragCounter = 0
+  dropZone.classList.remove('drag-over')
+})
 window.addEventListener('drop', (e) => {
   e.preventDefault()
   dragCounter = 0

--- a/app.js
+++ b/app.js
@@ -75,7 +75,7 @@ window.addEventListener('drop', (e) => {
   dragCounter = 0
   dropZone.classList.remove('drag-over')
   const file = e.dataTransfer.files[0]
-  if (file && file.name.endsWith('.csv')) {
+  if (file && file.name && file.name.toLowerCase().endsWith('.csv')) {
     loadFile(file)
   }
 })

--- a/app.js
+++ b/app.js
@@ -40,18 +40,26 @@ input.onchange = function () {
 // Drag-and-drop — listen on the whole window so any drop position works
 let dragCounter = 0
 
+function isFileDrag(e) {
+  if (!e || !e.dataTransfer || !e.dataTransfer.types) return false
+  return Array.prototype.indexOf.call(e.dataTransfer.types, 'Files') !== -1
+}
+
 window.addEventListener('dragenter', (e) => {
+  if (!isFileDrag(e)) return
   e.preventDefault()
   dragCounter++
   dropZone.classList.add('drag-over')
 })
 
-window.addEventListener('dragleave', () => {
+window.addEventListener('dragleave', (e) => {
+  if (!isFileDrag(e)) return
   dragCounter--
   if (dragCounter === 0) dropZone.classList.remove('drag-over')
 })
 
 window.addEventListener('dragover', (e) => {
+  if (!isFileDrag(e)) return
   e.preventDefault()
 })
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,18 @@
     </div>
   </div>
 
-  <input type="file" id="input-file" accept=".csv">
+  <div id="drop-zone">
+    <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+      <polyline points="14 2 14 8 20 8"/>
+      <line x1="12" y1="18" x2="12" y2="12"/>
+      <polyline points="9 15 12 12 15 15"/>
+    </svg>
+    <p class="drop-title">Drop your CSV file here</p>
+    <p class="drop-sub">or</p>
+    <label for="input-file" class="browse-btn">Browse file</label>
+    <input type="file" id="input-file" accept=".csv">
+  </div>
 
   <div id="handsontable-container"></div>
 

--- a/styles.css
+++ b/styles.css
@@ -55,10 +55,76 @@ body {
 .place-your-ad-here {
   display: inline-block;
   border: 3px solid #126BCF;
-  border-radius: 5px;
+  border-radius: 10px;
   color: #126BCF;
   font-weight: bold;
   padding: 10px 25px;
   text-align: center;
   line-height: 1.5;
+}
+
+/* Drop zone */
+#drop-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 360px;
+  padding: 48px 32px;
+  border: 2px dashed #c5d0de;
+  border-radius: 18px;
+  background: #f8fafc;
+  color: #64748b;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+#drop-zone.drag-over {
+  border-color: #126BCF;
+  background: #eff6ff;
+  color: #126BCF;
+}
+
+#drop-zone svg {
+  opacity: 0.5;
+}
+
+#drop-zone.drag-over svg {
+  opacity: 1;
+}
+
+.drop-title {
+  margin: 4px 0 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.drop-sub {
+  margin: 0;
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+#input-file {
+  display: none;
+}
+
+.browse-btn {
+  display: inline-block;
+  padding: 9px 24px;
+  background: #126BCF;
+  color: #fff;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s;
+  user-select: none;
+}
+
+.browse-btn:hover {
+  background: #0f5ab8;
 }

--- a/styles.css
+++ b/styles.css
@@ -76,7 +76,6 @@ body {
   border-radius: 18px;
   background: #f8fafc;
   color: #64748b;
-  cursor: pointer;
   transition: border-color 0.2s, background 0.2s;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -107,7 +107,16 @@ body {
 }
 
 #input-file {
-  display: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .browse-btn {


### PR DESCRIPTION
I’ve been using this tool quite a bit and found it really useful. One thing I felt was missing was drag-and-drop support for CSV uploads, so I decided to add it to improve the overall UX.

Previously, files could only be loaded via a plain <input type="file">. With this change, users can now drag and drop a CSV file anywhere on the window, or continue using the existing click-to-browse flow.

Changes
- Added a styled drop zone with upload icon and instructions
- Enabled window-level drag & drop (dragenter, dragleave, dragover, drop)
- Added visual highlight when a file is dragged over the page
- Preserved existing file input behavior (no breaking changes)
- Used a dragCounter to prevent flickering from nested drag events
- No core logic was modified — this is purely a UX enhancement.

Feedback welcome 🙂

p.s. Claude Code was used ))