### PR TITLE
Redesign as a persistent workbench UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,32 +1,63 @@
 const input = document.getElementById('input-file')
-const dropZone = document.getElementById('drop-zone')
+const openBtn = document.getElementById('open-btn')
+const searchInput = document.getElementById('search-input')
+const fileName = document.getElementById('file-name')
+const fileCount = document.getElementById('file-count')
 const handsontableContainer = document.getElementById('handsontable-container')
+
+let hot = null
+let allRows = []
+let fields = []
+
+const fmt = (n) => n.toLocaleString('en-US')
+
+function setCount(shown) {
+  fileCount.textContent = shown === allRows.length
+    ? fmt(allRows.length) + ' rows × ' + fields.length + ' cols'
+    : fmt(shown) + ' of ' + fmt(allRows.length) + ' rows'
+}
+
+function applySearch() {
+  const q = searchInput.value.trim().toLowerCase()
+  const rows = q
+    ? allRows.filter((row) => fields.some((f) => String(row[f] ?? '').toLowerCase().includes(q)))
+    : allRows
+
+  document.body.classList.toggle('no-match', rows.length === 0)
+  setCount(rows.length)
+  if (hot && rows.length) hot.loadData(rows)
+}
 
 function loadFile(file) {
   if (!file) return
   const reader = new FileReader()
 
   reader.onload = function (e) {
-    const csv = e.target.result
-    const data = Papa.parse(csv, {
+    const parsed = Papa.parse(e.target.result, {
       header: true,
       skipEmptyLines: true
     })
 
-    // reset container
-    handsontableContainer.innerHTML = ''
-    handsontableContainer.className = ''
-    dropZone.remove()
-    document.querySelector('.sponsors')?.remove()
-    document.querySelector('.top-sponsors')?.remove()
+    allRows = parsed.data
+    fields = parsed.meta.fields || []
+    searchInput.value = ''
 
-    Handsontable(handsontableContainer, {
-      data: data.data,
+    document.body.classList.add('loaded')
+    document.body.classList.remove('no-match')
+    fileName.textContent = file.name
+    setCount(allRows.length)
+
+    if (hot) hot.destroy()
+    hot = new Handsontable(handsontableContainer, {
+      data: allRows,
+      colHeaders: fields,
       rowHeaders: true,
-      colHeaders: data.meta.fields,
       columnSorting: true,
+      manualColumnResize: true,
+      stretchH: 'all',
       width: '100%',
-      licenseKey: 'non-commercial-and-evaluation',
+      height: '100%',
+      licenseKey: 'non-commercial-and-evaluation'
     })
   }
 
@@ -37,6 +68,23 @@ function loadFile(file) {
 input.onchange = function () {
   loadFile(this.files[0])
 }
+
+openBtn.onclick = function () {
+  input.click()
+}
+
+searchInput.oninput = applySearch
+
+window.addEventListener('keydown', (e) => {
+  if (e.key === '/' && document.activeElement !== searchInput && document.body.classList.contains('loaded')) {
+    e.preventDefault()
+    searchInput.focus()
+  }
+  if (e.key === 'Escape' && document.activeElement === searchInput) {
+    searchInput.value = ''
+    applySearch()
+  }
+})
 
 // Drag-and-drop — listen on the whole window so any drop position works
 let dragCounter = 0
@@ -50,16 +98,15 @@ window.addEventListener('dragenter', (e) => {
   if (!isFileDrag(e)) return
   e.preventDefault()
   dragCounter++
-  dropZone.classList.add('drag-over')
+  document.body.classList.add('drag-over')
 })
 
 window.addEventListener('dragleave', (e) => {
   if (!isFileDrag(e)) return
   dragCounter--
-  if (dragCounter === 0) dropZone.classList.remove('drag-over')
   if (dragCounter <= 0) {
     dragCounter = 0
-    dropZone.classList.remove('drag-over')
+    document.body.classList.remove('drag-over')
   }
 })
 
@@ -69,12 +116,13 @@ window.addEventListener('dragover', (e) => {
 
 window.addEventListener('dragend', () => {
   dragCounter = 0
-  dropZone.classList.remove('drag-over')
+  document.body.classList.remove('drag-over')
 })
+
 window.addEventListener('drop', (e) => {
   e.preventDefault()
   dragCounter = 0
-  dropZone.classList.remove('drag-over')
+  document.body.classList.remove('drag-over')
   const file = e.dataTransfer.files[0]
   if (file && file.name && file.name.toLowerCase().endsWith('.csv')) {
     loadFile(file)

--- a/index.html
+++ b/index.html
@@ -1,95 +1,108 @@
 <!doctype html>
+<html lang="en">
 <head>
-  <title>CSV Viewer Online</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CSV Viewer Online — open, sort and search a CSV in your browser</title>
+  <meta name="description" content="Open a CSV file and sort, resize and search it in your browser. Nothing is uploaded — your file is parsed locally on your own device.">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="./styles.css?3">
-  <meta name="description" content="Super SIMPLE viewer for CSV files">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/handsontable@13/dist/handsontable.full.min.css">
+  <link rel="stylesheet" href="./styles.css?4">
   <script defer src="https://analytics.limonte.dev/script.js" data-website-id="980b9c4c-d922-4759-91af-dc5d6a129f57"></script>
 </head>
 
 <body>
-  <div class="top-sponsors">
-    <div>
-      <a href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer" class="place-your-ad-here">
-        <p>YOUR AD HERE</p> <p> ~40k visitors monthly</p> <p>$19/month</p>
-      </a>
+  <header class="toolbar">
+    <span class="mark">
+      <svg width="17" height="17" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
+        <rect x="1.2" y="1.2" width="13.6" height="13.6" rx="2"/>
+        <path d="M1.2 5.6h13.6M6 5.6V14.8M10.4 5.6V14.8"/>
+      </svg>
+      <span>CSV Viewer</span>
+    </span>
+
+    <span class="divider"></span>
+
+    <span class="file-chip">
+      <span class="name" id="file-name">—</span>
+      <span class="count" id="file-count">—</span>
+    </span>
+    <span class="divider after-file"></span>
+
+    <span class="hint">Open a CSV to sort, resize and search it. Your file stays on your device.</span>
+    <span class="spacer"></span>
+
+    <span class="search">
+      <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true">
+        <circle cx="6.8" cy="6.8" r="4.6"/><path d="M10.2 10.2 14 14"/>
+      </svg>
+      <input type="search" id="search-input" placeholder="Search rows" aria-label="Search rows">
+      <kbd>/</kbd>
+    </span>
+
+    <button class="btn" id="open-btn" type="button">Open<span class="long"> file</span></button>
+  </header>
+
+  <main class="work">
+    <div class="empty">
+      <div id="drop-zone">
+        <svg class="file" width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+          <polyline points="14 2 14 8 20 8"/>
+          <line x1="12" y1="18" x2="12" y2="12"/>
+          <polyline points="9 15 12 12 15 15"/>
+        </svg>
+        <h1 class="drop-title">Drop your CSV file here</h1>
+        <p class="drop-sub">Parsed in your browser — the file is never uploaded.</p>
+        <label class="browse-btn" for="input-file">Browse file</label>
+        <input type="file" id="input-file" accept=".csv,text/csv">
+      </div>
     </div>
 
-    <div>
-      <a href="https://venopay.xyz/" target="_blank" rel="noopener" aria-label="VenoPay">
-        <img src="/images/venopay.png" alt="VenoPay" />
-        <br />
-        VenoPay
-      </a>
-    </div>
+    <div id="handsontable-container"></div>
 
-    <div>
-      <a href="https://www.inksonic.com/" target="_blank" rel="noopener" aria-label="InkSonic">
-        <img src="/images/inksonic.png" alt="InkSonic" />
-        <br />
-        InkSonic
-      </a>
-    </div>
+    <p class="search-empty" id="search-empty">No rows match that search. Clear the search to see all rows.</p>
+  </main>
 
-    <div>
-      <a href="https://vsdoll.net/" target="_blank" rel="noopener" aria-label="VSDoll">
-        <img src="/images/vsdoll.png" alt="VSDoll" />
-        <br />
-        VSDoll
-      </a>
-    </div>
+  <aside class="rail" aria-label="Sponsors">
+    <p class="rail-h">Sponsors</p>
 
-    <div>
-      <a href="https://www.blueplenum.com/" target="_blank" rel="noopener" aria-label="BluePlenum">
-        <img src="/images/blueplenum.jpg" alt="BluePlenum" />
-        <br />
-        BluePlenum
-      </a>
-    </div>
+    <a class="tile cta" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">
+      <b>Your ad here</b>
+      <span>~50k visitors monthly<br>$19/month</span>
+    </a>
 
-    <div>
-      <a href="https://www.zezelife.com/" target="_blank" rel="noopener" aria-label="ZezeLife">
-        <img src="/images/zezelife.png" alt="ZezeLife" />
-        <br />
-        ZezeLife
-      </a>
-    </div>
+    <a class="tile" href="https://venopay.xyz/" target="_blank" rel="noopener">
+      <img src="/images/venopay.png" alt=""> VenoPay
+    </a>
 
-    <div>
-      <a href="https://www.bsdoll.com/" target="_blank" rel="noopener" aria-label="BSDoll">
-        <img src="/images/bsdoll.jpg" alt="BSDoll" />
-        <br />
-        BSDoll
-      </a>
-    </div>
+    <a class="tile" href="https://www.inksonic.com/" target="_blank" rel="noopener">
+      <img src="/images/inksonic.png" alt=""> InkSonic
+    </a>
 
-    <div>
-      <a href="https://www.nakedoll.com/" target="_blank" rel="noopener" aria-label="NakeDoll">
-        <img src="/images/nakedoll.png" alt="NakeDoll" />
-        <br />
-        NakeDoll
-      </a>
-    </div>
-  </div>
+    <a class="tile" href="https://vsdoll.net/" target="_blank" rel="noopener">
+      <img src="/images/vsdoll.png" alt=""> VSDoll
+    </a>
 
-  <div id="drop-zone">
-    <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-      <polyline points="14 2 14 8 20 8"/>
-      <line x1="12" y1="18" x2="12" y2="12"/>
-      <polyline points="9 15 12 12 15 15"/>
-    </svg>
-    <p class="drop-title">Drop your CSV file here</p>
-    <p class="drop-sub">or</p>
-    <label for="input-file" class="browse-btn">Browse file</label>
-    <input type="file" id="input-file" accept=".csv">
-  </div>
+    <a class="tile" href="https://www.blueplenum.com/" target="_blank" rel="noopener">
+      <img src="/images/blueplenum.jpg" alt=""> BluePlenum
+    </a>
 
-  <div id="handsontable-container"></div>
+    <a class="tile" href="https://www.zezelife.com/" target="_blank" rel="noopener">
+      <img src="/images/zezelife.png" alt=""> ZezeLife
+    </a>
+
+    <a class="tile" href="https://www.bsdoll.com/" target="_blank" rel="noopener">
+      <img src="/images/bsdoll.jpg" alt=""> BSDoll
+    </a>
+
+    <a class="tile" href="https://www.nakedoll.com/" target="_blank" rel="noopener">
+      <img src="/images/nakedoll.png" alt=""> NakeDoll
+    </a>
+  </aside>
 
   <script src="https://cdn.jsdelivr.net/npm/handsontable@13/dist/handsontable.full.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5"></script>
-  <script src="./app.js?3"></script>
-
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/handsontable@13/dist/handsontable.full.min.css">
+  <script src="./app.js?4"></script>
 </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,142 +1,287 @@
-html, body {
-  height: 100%;
-  margin: 0;
+/* No webfonts: the product's promise is speed, so the type budget is spent
+   on nothing and the chrome uses the OS UI face. */
+:root {
+  --canvas: #FFFFFF;
+  --chrome: #F4F6FA;
+  --border: #D8DCE3;
+  --ink: #16181D;
+  --muted: #6B7280;
+  --action: #126BCF;
+  --action-soft: #EAF2FD;
+  --ui: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --data: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  --rail: 184px;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
 body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--rail);
+  grid-template-rows: 49px minmax(0, 1fr);
+  background: var(--canvas);
+  color: var(--ink);
+  font-family: var(--ui);
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+}
+
+:focus-visible {
+  outline: 2px solid var(--action);
+  outline-offset: 1px;
+}
+
+/* Toolbar — present both before and after a file is open, so the page is
+   never left without an identity. */
+.toolbar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 12px 0 14px;
+  background: var(--chrome);
+  border-bottom: 1px solid var(--border);
+}
+
+.mark {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  font-size: 13.5px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.mark svg {
+  color: var(--action);
+}
+
+.divider {
+  width: 1px;
+  height: 22px;
+  background: var(--border);
+  flex: 0 0 auto;
+}
+
+.divider.after-file {
+  display: none;
+}
+
+.file-chip {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+.file-chip .name {
+  font-family: var(--data);
+  font-size: 12.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-chip .count {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: var(--data);
+  font-size: 11px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+body.loaded .file-chip,
+body.loaded .divider.after-file {
+  display: flex;
+}
+
+.hint {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 12.5px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+body.loaded .hint {
+  display: none;
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+.search {
+  display: none;
+  position: relative;
+  flex: 0 1 260px;
+  min-width: 0;
+}
+
+body.loaded .search {
+  display: block;
+}
+
+.search svg {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted);
+  pointer-events: none;
+}
+
+.search input {
+  width: 100%;
+  height: 30px;
+  padding: 0 30px 0 28px;
+  background: var(--canvas);
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  font-family: var(--ui);
+  font-size: 13px;
+}
+
+.search input::placeholder {
+  color: var(--muted);
+}
+
+.search kbd {
+  position: absolute;
+  right: 7px;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 1px 5px;
+  background: var(--chrome);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: var(--data);
+  font-size: 10.5px;
+  color: var(--muted);
+}
+
+.search input:not(:placeholder-shown) + kbd,
+.search input:focus + kbd {
+  display: none;
+}
+
+.btn {
+  flex: 0 0 auto;
+  height: 30px;
+  padding: 0 14px;
+  background: var(--action);
+  color: #fff;
+  border: 0;
+  border-radius: 5px;
+  font-family: var(--ui);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background: #0F5AB8;
+}
+
+/* Work area */
+.work {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.empty {
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-family: Montserrat, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  gap: 4px;
+  padding: 24px;
+  background:
+    linear-gradient(var(--chrome) 1px, transparent 1px) 0 0 / 100% 33px,
+    linear-gradient(90deg, var(--chrome) 1px, transparent 1px) 0 0 / 132px 100%;
 }
 
-#handsontable-container.handsontable {
-  height: 100%;
-}
-
-.top-sponsors {
-  position: fixed;
-  top: 20px;
-  /* single centered row, wraps only if it doesn't fit */
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  column-gap: 30px;
-  width: 100%;
-  margin: auto;
-  font-size: 1.25em;
-}
-
-.top-sponsors div {
-  margin: 1em 0;
-  text-align: center;
-}
-
-.top-sponsors a {
-  display: inline-block;
-  min-width: 6.875em;
-  text-decoration: none;
-  text-align: center;
-}
-
-.top-sponsors img {
-  width: 80px;
-  height: 80px;
-}
-
-
-.sponsors {
-  position: fixed;
-  bottom: 20px;
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 20px;
-}
-
-.sponsors a {
-  margin: 0 30px;
-  display: inline-flex;
-  flex-direction: column;
-  border-radius: 5px;
-  text-decoration: none;
-  /* max-width: calc(300px + 2*20px + 2*3px); */
-}
-
-.sponsors a:hover {
-  text-decoration: underline;
-}
-
-.sponsors a span {
-  font-size: 14px;
-  margin-bottom: 18px;
-  text-align: center;
-}
-
-.sponsors > div {
-  text-align: center;
-}
-
-.place-your-ad-here {
-  width: 120px;
-  margin: 0 1em;
-  font-size: 13px;
-  border: 3px solid #126BCF;
-  border-radius: 10px;
-  color: #126BCF;
-  font-weight: bold;
-  padding: 5px;
-  text-align: center;
-  line-height: 1;
-}
-
-/* Drop zone */
 #drop-zone {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  width: 360px;
-  padding: 48px 32px;
-  border: 2px dashed #c5d0de;
-  border-radius: 18px;
-  background: #f8fafc;
-  color: #64748b;
-  transition: border-color 0.2s, background 0.2s;
-  z-index: 1;
+  gap: 10px;
+  width: 100%;
+  max-width: 400px;
+  padding: 42px 28px;
+  background: var(--canvas);
+  border: 2px dashed var(--border);
+  border-radius: 12px;
+  box-shadow: 0 18px 40px -30px rgba(22, 24, 29, 0.4);
+  transition: border-color 0.16s, background 0.16s;
 }
 
-#drop-zone.drag-over {
-  border-color: #126BCF;
-  background: #eff6ff;
-  color: #126BCF;
-}
-
-#drop-zone svg {
-  opacity: 0.5;
-}
-
-#drop-zone.drag-over svg {
-  opacity: 1;
+#drop-zone svg.file {
+  color: var(--muted);
+  opacity: 0.7;
+  transition: color 0.16s, opacity 0.16s, transform 0.16s;
 }
 
 .drop-title {
-  margin: 4px 0 0;
+  margin: 2px 0 0;
   font-size: 16px;
-  font-weight: 600;
-  color: #334155;
+  font-weight: 650;
 }
 
 .drop-sub {
   margin: 0;
-  font-size: 13px;
-  color: #94a3b8;
+  font-size: 12.5px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.browse-btn {
+  margin-top: 4px;
+  padding: 9px 20px;
+  background: var(--action);
+  color: #fff;
+  font-size: 13.5px;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.browse-btn:hover {
+  background: #0F5AB8;
+}
+
+body.drag-over #drop-zone {
+  border-color: var(--action);
+  background: var(--action-soft);
+}
+
+body.drag-over #drop-zone svg.file {
+  color: var(--action);
+  opacity: 1;
+  transform: translateY(-3px);
 }
 
 #input-file {
@@ -152,20 +297,210 @@ body {
   white-space: nowrap;
 }
 
-.browse-btn {
-  display: inline-block;
-  padding: 9px 24px;
-  background: #126BCF;
-  color: #fff;
-  font-family: inherit;
-  font-size: 14px;
-  font-weight: 600;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: background 0.15s;
-  user-select: none;
+#handsontable-container {
+  display: none;
+  height: 100%;
 }
 
-.browse-btn:hover {
-  background: #0f5ab8;
+body.loaded .empty {
+  display: none;
+}
+
+body.loaded #handsontable-container {
+  display: block;
+}
+
+/* The state class on <body> is deliberately different from the element's
+   class: sharing one would make `.x { display: none }` hide the page grid. */
+.search-empty {
+  display: none;
+  padding: 28px 20px;
+  text-align: center;
+  font-size: 13.5px;
+  color: var(--muted);
+}
+
+body.no-match #handsontable-container {
+  display: none;
+}
+
+body.no-match .search-empty {
+  display: block;
+}
+
+/* Grid */
+.handsontable {
+  font-family: var(--data);
+  font-size: 12.5px;
+  color: var(--ink);
+}
+
+.handsontable th {
+  background: var(--chrome);
+  color: var(--muted);
+  font-family: var(--ui);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.handsontable td {
+  border-color: #E7EAF0;
+}
+
+.handsontable .wtBorder.current,
+.handsontable .wtBorder.area {
+  background-color: var(--action) !important;
+}
+
+.handsontable td.area {
+  background-color: var(--action-soft);
+  background-image: none;
+}
+
+/* Sponsor rail — one uniform frame per tile, so a loud logo can't set the
+   tone of the whole page. */
+.rail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  padding: 10px;
+  background: var(--chrome);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+}
+
+.rail-h {
+  margin: 0 0 2px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #9AA3B2;
+}
+
+.tile {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex: 0 0 auto;
+  padding: 7px;
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ink);
+  text-decoration: none;
+  transition: border-color 0.14s, box-shadow 0.14s;
+}
+
+.tile:hover {
+  border-color: var(--action);
+  box-shadow: 0 0 0 3px var(--action-soft);
+}
+
+.tile img {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  object-fit: contain;
+}
+
+.tile.cta {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 11px;
+  background: var(--action-soft);
+  border: 1px dashed var(--action);
+  color: var(--action);
+}
+
+.tile.cta b {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.tile.cta span {
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.45;
+  color: #3D6EA8;
+}
+
+@media (max-width: 820px) {
+  :root {
+    --rail: 0px;
+  }
+
+  body {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: 49px minmax(0, 1fr) auto;
+  }
+
+  .toolbar {
+    flex-wrap: nowrap;
+    gap: 10px;
+    padding: 0 10px;
+  }
+
+  /* Keep the product name — it is the only identity on the page. */
+  .mark {
+    font-size: 13px;
+  }
+
+  .hint,
+  .divider {
+    display: none;
+  }
+
+  body.loaded .mark span,
+  body.loaded .divider.after-file {
+    display: none;
+  }
+
+  .search {
+    flex: 1 1 auto;
+  }
+
+  .btn span.long {
+    display: none;
+  }
+
+  .rail {
+    flex-direction: row;
+    align-items: center;
+    padding: 10px;
+    border-left: 0;
+    border-top: 1px solid var(--border);
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .rail-h {
+    display: none;
+  }
+
+  .tile {
+    white-space: nowrap;
+  }
+
+  .tile.cta {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .tile.cta span {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+  }
 }


### PR DESCRIPTION
Replaces the floating drop-card landing page with an app-style layout: a toolbar that stays present before *and* after a file is opened, and a sponsor rail with uniform tile framing.

## Why

The old page removed the drop zone, the sponsors and every trace of product identity the moment a CSV loaded — so the longest part of a session had no branding and **no ad impressions**. It also broke at common viewport sizes.

| | Before | After |
|---|---|---|
| After a file loads | drop zone, ads and identity all removed | toolbar, filename, row/col count, search and ads all persist |
| `index.html` head | no `<html>`, no charset, no viewport meta | all three present, `lang="en"` |
| Fonts | `Montserrat` declared but never loaded → rendered as Helvetica | system UI + system mono, zero webfont bytes |
| Handsontable CSS | `<link>` after the scripts at end of `<body>` | in `<head>`, before `styles.css` |
| Grid width | no `stretchH`, table never filled the width | `stretchH: 'all'` |
| `styles.css` | ~40 lines of dead `.sponsors` rules for a removed element | none left |
| Body text | zero text content, no `<h1>` | real `<h1>` + description |

## Layout fixes

- The fixed-position drop zone **overlapped the sponsor grid** below 1280px (the 8th logo wrapped and was clipped behind it) and **ran off the right edge** at 390px.
- Without `<meta name="viewport">`, phones laid the page out at 980px and scaled everything down.

## New

- Persistent toolbar: wordmark, filename, `N rows × M cols`, row search, `Open file`.
- Working row search — filters across all columns, shows `4 of 10 rows`, `/` focuses it and `Esc` clears it.
- Sponsor rail (184px) with one uniform frame per tile, so a loud logo can't set the tone of the page. Collapses to a horizontal scroll strip under 820px.
- Sponsor CTA now reads **~50k visitors monthly**.

## Verification

Driven with Playwright at 1440 / 1280 / 390, in both the empty and loaded states:

- No console errors; no horizontal overflow outside the intentionally scrollable rail.
- All 8 sponsor tiles render at every width and survive file load.
- Search verified end to end: `shipped` → 4 rows, `zzz` → no-match message with the page intact, cleared → back to 10.
- Keyboard: visible `:focus-visible` outlines; `prefers-reduced-motion` respected.

Cache busters bumped to `?4`. The title keeps "CSV Viewer Online" as its leading phrase so the existing ranking for it isn't disturbed.

> [!NOTE]
> This repo publishes GitHub Pages from `main`, so merging deploys straight to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)