### PR TITLE
Replace favicon with the toolbar grid mark

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,9 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#10B981"/> <text x="50%" y="65%" 
-        font-family="system-ui, sans-serif" 
-        font-size="12" 
-        font-weight="900" 
-        fill="#FFFFFF" 
-        text-anchor="middle" 
-        letter-spacing="-0.5">CSV</text>
+  <rect width="32" height="32" rx="6" fill="#126BCF"/>
+  <rect x="7" y="7" width="18" height="18" rx="1.5" fill="#FFFFFF"/>
+  <rect x="7" y="12" width="18" height="2.5" fill="#126BCF"/>
+  <rect x="14.75" y="14.5" width="2.5" height="10.5" fill="#126BCF"/>
 </svg>


### PR DESCRIPTION
Unifies the favicon with the toolbar mark introduced in #8.

## Why

The favicon was a green `CSV` wordmark (`#10B981`) while the toolbar mark is a blue grid glyph (`#126BCF`) — two different marks in two different colours for the same product.

```
before                     after
┌──────────┐               ┌──────────┐
│   CSV    │  green        │  ▛▀▀▜     │  brand blue #126BCF
│          │  wordmark     │  ▙▄▟      │  grid mark, matches toolbar
└──────────┘               └──────────┘
```

## Not a verbatim copy of the toolbar glyph

The toolbar glyph is drawn for 17px with a 1.4px stroke and **three** interior divisions. At 16px in a tab strip those columns merge into grey mush. This is the same concept redrawn for the small size:

- filled paths instead of strokes, so edges stay crisp
- **one** interior division instead of two
- kept on a solid blue block, so the icon has a findable silhouette in a crowded tab strip and doesn't recede on dark tab strips the way a bare blue glyph does

A bare-glyph variant matching the toolbar exactly was also drawn and compared; it looks better at 48–64px but loses legibility at 16px and contrast on dark strips, which is where a favicon actually gets seen.

## Also fixes a latent bug

The old favicon rendered its `CSV` text in `system-ui` **inside the SVG**, so letterforms varied by OS — and SVG-favicon renderers that don't resolve `system-ui` could drop the text entirely, leaving a blank green square. The new icon is pure paths with no font dependency.

## Verification

Rendered from the actual file on this branch at 16 / 24 / 32 / 48px and composited into simulated light and dark tab strips. Decodes cleanly at every size (`naturalWidth > 0`), no failed requests.

> [!NOTE]
> Browsers cache favicons aggressively and the filename is unchanged, so a hard refresh may be needed to see it update on the live site after merge. Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)