### PR TITLE
Mark paid sponsor links rel="sponsored"

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,31 +72,31 @@
       <span>~50k visitors monthly<br>$19/month</span>
     </a>
 
-    <a class="tile" href="https://venopay.xyz/" target="_blank" rel="noopener">
+    <a class="tile" href="https://venopay.xyz/" target="_blank" rel="noopener sponsored">
       <img src="/images/venopay.png" alt=""> VenoPay
     </a>
 
-    <a class="tile" href="https://www.inksonic.com/" target="_blank" rel="noopener">
+    <a class="tile" href="https://www.inksonic.com/" target="_blank" rel="noopener sponsored">
       <img src="/images/inksonic.png" alt=""> InkSonic
     </a>
 
-    <a class="tile" href="https://vsdoll.net/" target="_blank" rel="noopener">
+    <a class="tile" href="https://vsdoll.net/" target="_blank" rel="noopener sponsored">
       <img src="/images/vsdoll.png" alt=""> VSDoll
     </a>
 
-    <a class="tile" href="https://www.blueplenum.com/" target="_blank" rel="noopener">
+    <a class="tile" href="https://www.blueplenum.com/" target="_blank" rel="noopener sponsored">
       <img src="/images/blueplenum.jpg" alt=""> BluePlenum
     </a>
 
-    <a class="tile" href="https://www.zezelife.com/" target="_blank" rel="noopener">
+    <a class="tile" href="https://www.zezelife.com/" target="_blank" rel="noopener sponsored">
       <img src="/images/zezelife.png" alt=""> ZezeLife
     </a>
 
-    <a class="tile" href="https://www.bsdoll.com/" target="_blank" rel="noopener">
+    <a class="tile" href="https://www.bsdoll.com/" target="_blank" rel="noopener sponsored">
       <img src="/images/bsdoll.jpg" alt=""> BSDoll
     </a>
 
-    <a class="tile" href="https://www.nakedoll.com/" target="_blank" rel="noopener">
+    <a class="tile" href="https://www.nakedoll.com/" target="_blank" rel="noopener sponsored">
       <img src="/images/nakedoll.png" alt=""> NakeDoll
     </a>
   </aside>


### PR DESCRIPTION
Closes #10.

## What

Adds `sponsored` to the `rel` on all 7 outbound sponsor links. `noopener` is preserved on every one.

```diff
-<a class="tile" href="https://venopay.xyz/" target="_blank" rel="noopener">
+<a class="tile" href="https://venopay.xyz/" target="_blank" rel="noopener sponsored">
```

## Why

These are paid placements at **$19/month**. [Google's link spam policy](https://developers.google.com/search/docs/essentials/spam-policies#link-spam) requires links bought for money to be qualified with `rel="sponsored"` or `rel="nofollow"`. Leaving them unqualified is a manual-action risk, and the exposure is higher than average here: a single page with very little content and 7 paid outbound links is a recognisable link-scheme pattern.

## Verified

Audited the rendered DOM, not just the source:

```
tiles: 8
  ok | Your ad here   | (none)                 | mailto:csv-viewer-online@tianon.an
  ok | VenoPay        | noopener sponsored     | https://venopay.xyz/
  ok | InkSonic       | noopener sponsored     | https://www.inksonic.com/
  ok | VSDoll         | noopener sponsored     | https://vsdoll.net/
  ok | BluePlenum     | noopener sponsored     | https://www.blueplenum.com/
  ok | ZezeLife       | noopener sponsored     | https://www.zezelife.com/
  ok | BSDoll         | noopener sponsored     | https://www.bsdoll.com/
  ok | NakeDoll       | noopener sponsored     | https://www.nakedoll.com/

paid links: 7 | all sponsored: true
all keep noopener: true
mailto not sponsored: true
no page errors
```

- All 8 tiles still render and are clickable (non-zero hit area)
- The `mailto:` "Your ad here" CTA is **deliberately left unqualified** — it is not a paid link
- No visual change; `rel` has no rendering effect

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)