### PR TITLE
Give the page a real h1 instead of button copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,8 @@
       <span class="name" id="file-name">—</span>
       <span class="count" id="file-count">—</span>
     </span>
-    <span class="divider after-file"></span>
+    <span class="divider"></span>
 
-    <span class="hint">Open a CSV to sort, resize and search it. Your file stays on your device.</span>
     <span class="spacer"></span>
 
     <span class="search">
@@ -45,6 +44,11 @@
 
   <main class="work">
     <div class="empty">
+      <div class="intro">
+        <h1>CSV Viewer Online</h1>
+        <p class="tagline">Open, sort and search a CSV file. Nothing is uploaded — it is parsed on your own device.</p>
+      </div>
+
       <div id="drop-zone">
         <svg class="file" width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
@@ -52,7 +56,7 @@
           <line x1="12" y1="18" x2="12" y2="12"/>
           <polyline points="9 15 12 12 15 15"/>
         </svg>
-        <h1 class="drop-title">Drop your CSV file here</h1>
+        <p class="drop-title">Drop your CSV file here</p>
         <p class="drop-sub">Parsed in your browser — the file is never uploaded.</p>
         <label class="browse-btn" for="input-file">Browse file</label>
         <input type="file" id="input-file" accept=".csv,text/csv">

--- a/styles.css
+++ b/styles.css
@@ -64,15 +64,17 @@ body {
   color: var(--action);
 }
 
+/* Dividers only separate things that exist once a file is open. */
 .divider {
+  display: none;
   width: 1px;
   height: 22px;
   background: var(--border);
   flex: 0 0 auto;
 }
 
-.divider.after-file {
-  display: none;
+body.loaded .divider {
+  display: block;
 }
 
 .file-chip {
@@ -104,23 +106,8 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
-body.loaded .file-chip,
-body.loaded .divider.after-file {
+body.loaded .file-chip {
   display: flex;
-}
-
-.hint {
-  flex: 1 1 auto;
-  min-width: 0;
-  font-size: 12.5px;
-  color: var(--muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-body.loaded .hint {
-  display: none;
 }
 
 .spacer {
@@ -220,6 +207,28 @@ body.loaded .search {
   background:
     linear-gradient(var(--chrome) 1px, transparent 1px) 0 0 / 100% 33px,
     linear-gradient(90deg, var(--chrome) 1px, transparent 1px) 0 0 / 132px 100%;
+}
+
+/* Empty-state heading. Lives inside .empty, so it is removed as soon as a
+   file is open and never competes with the grid. */
+.intro {
+  margin-bottom: 22px;
+  max-width: 460px;
+  text-align: center;
+}
+
+.intro h1 {
+  margin: 0 0 7px;
+  font-size: 27px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+.tagline {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted);
 }
 
 #drop-zone {
@@ -452,18 +461,26 @@ body.no-match .search-empty {
     font-size: 13px;
   }
 
-  .hint,
-  .divider {
-    display: none;
-  }
-
+  /* No room for dividers or the wordmark text next to a filename. */
   body.loaded .mark span,
-  body.loaded .divider.after-file {
+  body.loaded .divider {
     display: none;
   }
 
   .search {
     flex: 1 1 auto;
+  }
+
+  .intro {
+    margin-bottom: 18px;
+  }
+
+  .intro h1 {
+    font-size: 21px;
+  }
+
+  .tagline {
+    font-size: 13px;
   }
 
   .btn span.long {


### PR DESCRIPTION
Closes #11.

## What

```diff
+<div class="intro">
+  <h1>CSV Viewer Online</h1>
+  <p class="tagline">Open, sort and search a CSV file. Nothing is uploaded — it is parsed on your own device.</p>
+</div>
 <div id="drop-zone">
-  <h1 class="drop-title">Drop your CSV file here</h1>
+  <p class="drop-title">Drop your CSV file here</p>
```

The intro lives inside `.empty`, so it is removed the moment a file opens and never competes with the grid. Verified: `introVisible: false` in the loaded state at all three widths.

## Also removed the toolbar hint

The hint read *"Open a CSV to sort, resize and search it. Your file stays on your device."* — almost exactly what the new tagline says. Both were only ever visible in the same state, so they were duplicating each other on screen. Removing the hint had two knock-on cleanups:

- The leading `.divider` had nothing left to separate in the empty state, so dividers now only show once a file is open.
- `.after-file` no longer had any CSS rules, so the modifier is dropped rather than left as dead markup.

`grep -c` confirms zero remaining references to `hint` or `after-file` in either file.

## Verified

At 1440 / 1280 / 390, empty and loaded:

```
desktop { headings: ["H1: CSV Viewer Online"], h1Count: 1, dropTitleTag: "P",
          hScroll: false, vScroll: false, dropCardFullyVisible: true }
  loaded: { introVisible: false, gridRows: 10 }
laptop  { … same … }   mobile { … same … }
no page errors
```

- Exactly one `h1`, and it is no longer button copy
- Drop card stays fully within the viewport at every width — the added heading does not push it off screen
- No horizontal or vertical overflow introduced
- Grid still renders 10 rows after load

## Not included

The body-content work is #12, which needs the same "let the empty state scroll" layout change. This PR deliberately keeps the empty state non-scrolling so the two changes stay reviewable apart.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)