### PR TITLE
Add body content to the empty state

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 
   <main class="work">
     <div class="empty">
+      <div class="hero">
       <div class="intro">
         <h1>CSV Viewer Online</h1>
         <p class="tagline">Open, sort and search a CSV file. Nothing is uploaded — it is parsed on your own device.</p>
@@ -61,6 +62,42 @@
         <label class="browse-btn" for="input-file">Browse file</label>
         <input type="file" id="input-file" accept=".csv,text/csv">
       </div>
+
+        <a class="scroll-cue" href="#about">How it works</a>
+      </div>
+
+      <article class="content" id="about">
+        <h2>Read a CSV without handing it to anyone</h2>
+        <p>Most online CSV tools ask you to upload your file to a server before you can look at it. A copy of your spreadsheet — customer records, a bank export, whatever it happens to be — then lives on someone else's machine, under their retention policy rather than yours.</p>
+        <p>This page does the work in your browser instead. When you pick a file it is read straight from disk by the tab you already have open, parsed in memory, and drawn on screen. There is no account, nothing to delete afterwards, and no upload request carrying your data. You can check that yourself: open your browser's network panel and watch it while you open a file.</p>
+
+        <h2>What it handles</h2>
+        <ul>
+          <li><strong>Commas, semicolons, tabs and pipes.</strong> The separator is detected automatically, so European semicolon exports and tab-separated files open without changing a setting.</li>
+          <li><strong>Quoted fields.</strong> Values wrapped in quotes can contain commas, escaped quotes and line breaks.</li>
+          <li><strong>UTF-8 text.</strong> Accented characters and non-Latin scripts render as written.</li>
+          <li><strong>Sorting.</strong> Click a column header to sort by that column.</li>
+          <li><strong>Column widths.</strong> Drag the edge of a header to resize it.</li>
+          <li><strong>Search.</strong> Filter to matching rows across every column; press <kbd>/</kbd> to jump to the search box.</li>
+        </ul>
+
+        <h2>Questions</h2>
+
+        <h3>Is my file uploaded anywhere?</h3>
+        <p>No. It is read and parsed locally by JavaScript running in this tab, and never leaves your device.</p>
+
+        <h3>How many rows can it open?</h3>
+        <p>There is no fixed limit. Rows are only drawn as they scroll into view, so tens of thousands are comfortable. Very large files are bounded by your device's memory rather than by the page.</p>
+
+        <h3>Can I edit the data and save it?</h3>
+        <p>You can type into a cell to check something, but there is no export. Nothing is written back to your file, and edits are gone when you reload. This is a viewer, not a spreadsheet editor.</p>
+
+        <h3>Does it work offline?</h3>
+        <p>Not at the moment. The grid and the CSV parser are fetched from a CDN when the page loads, so the first load needs a connection. Reading your file, once the page is open, does not.</p>
+
+        <h3>What does it cost?</h3>
+        <p>Nothing — it is free to use. The sponsor tiles on this page are paid placements.</p>
+      </article>
     </div>
 
     <div id="handsontable-container"></div>

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@
   --border: #D8DCE3;
   --ink: #16181D;
   --muted: #6B7280;
+  --prose: #3F4653;
   --action: #126BCF;
   --action-soft: #EAF2FD;
   --ui: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
@@ -195,9 +196,17 @@ body.loaded .search {
   overflow: hidden;
 }
 
+/* Scroll container: the hero fills the first viewport, the prose sits
+   below it. The whole thing is removed once a file is open. */
 .empty {
   position: absolute;
   inset: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.hero {
+  min-height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -207,6 +216,67 @@ body.loaded .search {
   background:
     linear-gradient(var(--chrome) 1px, transparent 1px) 0 0 / 100% 33px,
     linear-gradient(90deg, var(--chrome) 1px, transparent 1px) 0 0 / 132px 100%;
+}
+
+.scroll-cue {
+  margin-top: 30px;
+  font-size: 12.5px;
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.scroll-cue::after {
+  content: ' ↓';
+}
+
+.scroll-cue:hover {
+  color: var(--action);
+}
+
+/* Prose */
+.content {
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 10px 24px 76px;
+}
+
+.content h2 {
+  margin: 36px 0 10px;
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.content h3 {
+  margin: 22px 0 5px;
+  font-size: 14.5px;
+  font-weight: 650;
+}
+
+.content p,
+.content li {
+  margin: 0 0 10px;
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--prose);
+}
+
+.content ul {
+  margin: 12px 0 0;
+  padding-left: 20px;
+}
+
+.content li {
+  margin-bottom: 7px;
+}
+
+.content kbd {
+  padding: 1px 5px;
+  background: var(--chrome);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: var(--data);
+  font-size: 11.5px;
 }
 
 /* Empty-state heading. Lives inside .empty, so it is removed as soon as a
@@ -481,6 +551,15 @@ body.no-match .search-empty {
 
   .tagline {
     font-size: 13px;
+  }
+
+  .content {
+    padding: 6px 18px 60px;
+  }
+
+  .content h2 {
+    font-size: 17px;
+    margin-top: 30px;
   }
 
   .btn span.long {


### PR DESCRIPTION
Closes #12.

## What

The served document was **4 KB with about one sentence of prose**. That was the ceiling on organic reach — the page competes for "csv viewer" against pages with real content, from a page with none.

**378 words** across three `h2` sections and five FAQ entries, giving a clean `h1 → h2 → h3` outline:

```
H1  CSV Viewer Online
H2  Read a CSV without handing it to anyone
H2  What it handles
H2  Questions
H3    Is my file uploaded anywhere?
H3    How many rows can it open?
H3    Can I edit the data and save it?
H3    Does it work offline?
H3    What does it cost?
```

## The layout change

There was no below-the-fold to put content in, so `.empty` becomes a scroll container:

- `.hero` keeps `min-height: 100%` and stays vertically centred — the drop card still owns the first viewport
- an `<article class="content">` sits beneath it
- both live inside `.empty`, so the whole thing is removed the moment a file opens and never intrudes on the grid
- a small "How it works ↓" cue makes the content discoverable

## Every claim is verified, not assumed

I tested each statement against the running app before writing it:

| Claim in the copy | Test result |
|---|---|
| Comma, semicolon, tab, pipe auto-detected | ✅ all four parsed into correct columns |
| Quoted fields w/ commas, escaped quotes, newlines | ✅ round-tripped intact |
| UTF-8 incl. non-Latin scripts | ✅ `José`, `São Paulo`, `東京` correct |
| Sorting / column resize / search | ✅ all present and working |
| Cells editable **but no export** | ✅ edit persisted on screen; no download UI exists |
| Works offline | ❌ **fails with CDN blocked, no service worker** |

The last two are why the FAQ says edits are *lost on reload* rather than implying the file can be saved, and says offline **does not work** rather than claiming it does. Two claims I'd have got wrong from assumption alone.

The cost answer also states plainly that the sponsor tiles are paid placements, which pairs with the `rel="sponsored"` work in #10.

## Verified

At 1440 / 1280 / 390:

```
outline: H1,H2,H2,H2,H3,H3,H3,H3,H3   words: 378
pageHScroll: false   pageVScroll: false   emptyScrollable: true
heroFillsViewport: true   dropVisibleNoScroll: true   contentBelowFold: true
loaded: { contentVisible: false, heroVisible: false, gridRows: 10 }
no page errors
```

- Drop card is still fully visible **without scrolling** at every width — the content does not push the tool down
- Scrolling is contained in `.empty`; no page-level scrollbar is introduced
- Content and hero both vanish when a file is open; grid still renders

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)