### PR TITLE
Fetch the grid on first file open instead of on every page view

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const openBtn = document.getElementById('open-btn')
 const searchInput = document.getElementById('search-input')
 const fileName = document.getElementById('file-name')
 const fileCount = document.getElementById('file-count')
+const dropStatus = document.getElementById('drop-status')
 const handsontableContainer = document.getElementById('handsontable-container')
 
 let hot = null
@@ -10,6 +11,46 @@ let allRows = []
 let fields = []
 
 const fmt = (n) => n.toLocaleString('en-US')
+
+// The grid is ~1.6 MB and the parser is only needed once a file is chosen,
+// so both are fetched on first open instead of on every page view.
+const CDN = 'https://cdn.jsdelivr.net/npm/'
+const DEPS = [
+  { tag: 'link', url: CDN + 'handsontable@13/dist/handsontable.full.min.css' },
+  { tag: 'script', url: CDN + 'handsontable@13/dist/handsontable.full.min.js' },
+  { tag: 'script', url: CDN + 'papaparse@5' }
+]
+
+let depsPromise = null
+
+function injectDep(dep) {
+  return new Promise((resolve, reject) => {
+    const el = document.createElement(dep.tag)
+    el.onload = resolve
+    el.onerror = () => reject(new Error('could not load ' + dep.url))
+    if (dep.tag === 'link') {
+      el.rel = 'stylesheet'
+      el.href = dep.url
+    } else {
+      el.src = dep.url
+    }
+    document.head.appendChild(el)
+  })
+}
+
+function loadDeps() {
+  if (!depsPromise) depsPromise = Promise.all(DEPS.map(injectDep))
+  return depsPromise
+}
+
+function readAsText(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = () => reject(reader.error || new Error('could not read file'))
+    reader.readAsText(file)
+  })
+}
 
 function setCount(shown) {
   fileCount.textContent = shown === allRows.length
@@ -28,45 +69,60 @@ function applySearch() {
   if (hot && rows.length) hot.loadData(rows)
 }
 
-function loadFile(file) {
-  if (!file) return
-  const reader = new FileReader()
+function render() {
+  if (hot) hot.destroy()
+  hot = new Handsontable(handsontableContainer, {
+    data: allRows,
+    colHeaders: fields,
+    rowHeaders: true,
+    columnSorting: true,
+    manualColumnResize: true,
+    stretchH: 'all',
+    width: '100%',
+    height: '100%',
+    licenseKey: 'non-commercial-and-evaluation'
+  })
+}
 
-  reader.onload = function (e) {
-    const parsed = Papa.parse(e.target.result, {
-      header: true,
-      skipEmptyLines: true
-    })
+async function loadFile(file) {
+  if (!file) return
+
+  document.body.classList.remove('load-error')
+  document.body.classList.add('loading')
+  dropStatus.textContent = 'Opening ' + file.name + '…'
+
+  try {
+    const [text] = await Promise.all([readAsText(file), loadDeps()])
+    const parsed = Papa.parse(text, { header: true, skipEmptyLines: true })
 
     allRows = parsed.data
     fields = parsed.meta.fields || []
     searchInput.value = ''
 
+    document.body.classList.remove('loading', 'no-match')
     document.body.classList.add('loaded')
-    document.body.classList.remove('no-match')
+    dropStatus.textContent = ''
     fileName.textContent = file.name
     setCount(allRows.length)
 
-    if (hot) hot.destroy()
-    hot = new Handsontable(handsontableContainer, {
-      data: allRows,
-      colHeaders: fields,
-      rowHeaders: true,
-      columnSorting: true,
-      manualColumnResize: true,
-      stretchH: 'all',
-      width: '100%',
-      height: '100%',
-      licenseKey: 'non-commercial-and-evaluation'
-    })
+    render()
+  } catch (err) {
+    console.error('csv-viewer: open failed', err)
+    // Let the next attempt refetch rather than reusing a rejected promise.
+    depsPromise = null
+    document.body.classList.remove('loading')
+    document.body.classList.add('load-error')
+    dropStatus.textContent = 'Could not open that file. Check your connection and try again.'
   }
-
-  reader.readAsText(file)
 }
 
-// Click-to-browse
+// Click-to-browse. Clearing the value means picking the same file again
+// still fires change — otherwise retrying a failed open, or reopening a
+// file that changed on disk, would silently do nothing.
 input.onchange = function () {
-  loadFile(this.files[0])
+  const file = this.files[0]
+  this.value = ''
+  loadFile(file)
 }
 
 openBtn.onclick = function () {

--- a/index.html
+++ b/index.html
@@ -6,8 +6,10 @@
   <title>CSV Viewer Online — open, sort and search a CSV in your browser</title>
   <meta name="description" content="Open a CSV file and sort, resize and search it in your browser. Nothing is uploaded — your file is parsed locally on your own device.">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/handsontable@13/dist/handsontable.full.min.css">
-  <link rel="stylesheet" href="./styles.css?4">
+  <link rel="stylesheet" href="./styles.css?5">
+  <!-- The grid and parser are fetched on first file open (see app.js), so
+       warm the connection now rather than paying for it then. -->
+  <link rel="preconnect" href="https://cdn.jsdelivr.net">
   <script defer src="https://analytics.limonte.dev/script.js" data-website-id="980b9c4c-d922-4759-91af-dc5d6a129f57"></script>
 </head>
 
@@ -63,6 +65,7 @@
         <input type="file" id="input-file" accept=".csv,text/csv">
       </div>
 
+        <p class="drop-status" id="drop-status" role="status" aria-live="polite"></p>
         <a class="scroll-cue" href="#about">How it works</a>
       </div>
 
@@ -142,8 +145,6 @@
     </a>
   </aside>
 
-  <script src="https://cdn.jsdelivr.net/npm/handsontable@13/dist/handsontable.full.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5"></script>
-  <script src="./app.js?4"></script>
+  <script src="./app.js?5"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -218,6 +218,36 @@ body.loaded .search {
     linear-gradient(90deg, var(--chrome) 1px, transparent 1px) 0 0 / 132px 100%;
 }
 
+/* Shown while the grid is being fetched on first open, and if that fails. */
+.drop-status {
+  display: none;
+  margin: 16px 0 0;
+  max-width: 340px;
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+  color: var(--muted);
+}
+
+body.loading .drop-status,
+body.load-error .drop-status {
+  display: block;
+}
+
+body.load-error .drop-status {
+  color: #B42318;
+}
+
+body.loading #drop-zone {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+body.loading .scroll-cue,
+body.load-error .scroll-cue {
+  visibility: hidden;
+}
+
 .scroll-cue {
   margin-top: 30px;
   font-size: 12.5px;


### PR DESCRIPTION
Closes #13.

## Result

| | Before | After |
|---|---:|---:|
| Initial page weight | 1,826 KB | **105 KB** |
| Requests | 15 | 12 |
| LCP | 496 ms | **44 ms** |
| CLS | 0 | 0 |

**94% smaller initial load.** `handsontable.full.min.js` (1.67 MB, 92% of the old total) and `papaparse` are now injected on first file open, behind a memoised promise so a second file does not refetch. A `preconnect` to `cdn.jsdelivr.net` keeps the deferred fetch warm.

## Two new states, handled explicitly

Deferring the fetch moves a failure mode from page load to file open, so both new states are real UI rather than a silent hang:

- **Loading** — `Opening sample.csv…` under a dimmed drop zone
- **Failed** — `Could not open that file. Check your connection and try again.` in red, with the drop zone left usable

The rejected promise is discarded so a retry refetches rather than reusing it, and the failure is logged to the console instead of being swallowed.

## A dead end this exposed

While testing the retry path I found that re-picking **the same file** fires **zero** `change` events — so the most obvious way to retry a failed open, choosing that file again, silently did nothing:

```
attempt 2 — SAME file re-selected, CDN recovered:
   change events fired: 0   rows: 0   load-error: true    ← stuck
```

Clearing `input.value` in the change handler fixes it, and also means reopening a file that changed on disk now works:

```
attempt 2 — SAME file re-selected, CDN recovered:
   change events fired: 1   rows: 10   load-error: false  ← recovers
```

## Verified

```
INITIAL LOAD
  total: 105 KB / 12 requests
  handsontable requested: false
  papaparse requested   : false
  LCP 44ms  CLS 0

FIRST OPEN
  handsontable fetched: true   deferred bytes: 1728 KB
  rows rendered: 10   chip: 10 rows × 9 cols   loading class cleared: true

SECOND OPEN
  refetched deps: false (want false)   rows rendered: 2

CDN BLOCKED
  error shown: true | "Could not open that file. Check your connection and try again."
  page still usable (drop zone present): true
  RETRY after CDN recovers -> rows: 10   error cleared: true

no page errors
```

Cache busters bumped to `?5`.

> [!NOTE]
> The FAQ added in #19 already states the page needs a connection on first load, so it stays accurate — the dependency simply moves from page load to first open.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)