### PR TITLE
Add robots.txt and sitemap.xml

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://csv-viewer-online.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://csv-viewer-online.github.io/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
Part of #15 — deliberately **not** `Closes`, see below.

## What

Both files were 404. Marginal for a one-page site since crawlers find `/` either way, but they remove ambiguity and cost ten lines.

**`robots.txt`**
```
User-agent: *
Allow: /

Sitemap: https://csv-viewer-online.github.io/sitemap.xml
```

**`sitemap.xml`** — one URL, no `lastmod` (it would go stale and Google ignores inaccurate values).

## A bug in my own issue snippet

The namespace I wrote in #15 was `http://www.sitemap.org/…` — **singular**. The correct one is `http://www.sitemaps.org/…`. The singular form silently invalidates the whole file, so it's fixed here.

## Verified

```
=== served status + content-type ===
robots.txt    200  Content-type: text/plain
sitemap.xml   200  Content-type: application/xml

=== sitemap XML well-formed + correct namespace ===
parses            : True
root tag          : {http://www.sitemaps.org/schemas/sitemap/0.9}urlset
namespace correct : True
urls              : ['https://csv-viewer-online.github.io/']
all absolute https: True

=== robots.txt parses (urllib RobotFileParser) ===
allows / for *    : True
sitemaps declared : ['https://csv-viewer-online.github.io/sitemap.xml']

=== sitemap URL must match canonical exactly ===
canonical: https://csv-viewer-online.github.io/
sitemap  : https://csv-viewer-online.github.io/
MATCH
```

`robots.txt` is parsed with a real robots parser rather than eyeballed, the sitemap is parsed as XML with its namespace asserted, and the `<loc>` is asserted equal to the canonical added in #22 — so the two can't drift apart and disagree about which URL is authoritative.

## Why #15 stays open

The part of that issue that actually matters is **Search Console / Bing Webmaster verification**, which needs your account access — I can't do it from the repo. Right now there's Umami traffic data but zero visibility into queries, impressions or indexing status.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)