### PR TITLE
Use the HTML-tag Search Console token

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Open a CSV file and sort, resize and search it in your browser. Nothing is uploaded — your file is parsed locally on your own device.">
   <link rel="canonical" href="https://csv-viewer-online.github.io/">
   <!-- Search Console ownership proof. Removing this un-verifies the site. -->
-  <meta name="google-site-verification" content="m0A3okYBxSPb9KF0JKVbxAX6tmXBWS25WmaApwPK_1w">
+  <meta name="google-site-verification" content="X0qzkZX4WRevYnA61X4xX3AR9oHcX12rpl2OiykK05k">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
 
   <meta property="og:type" content="website">


### PR DESCRIPTION
Part of #15.

Swaps the verification token for the one the **HTML tag** method issued.

```diff
-<meta name="google-site-verification" content="m0A3okYBxSPb9KF0JKVbxAX6tmXBWS25WmaApwPK_1w">
+<meta name="google-site-verification" content="X0qzkZX4WRevYnA61X4xX3AR9oHcX12rpl2OiykK05k">
```

The token in #24 came from the DNS flow, and Google issues method-specific tokens — the HTML tag method did hand out a different string, confirming that the earlier one would never have verified.

## Verified

```
{ "present": true,
  "content": "X0qzkZX4WRevYnA61X4xX3AR9oHcX12rpl2OiykK05k",
  "inHead": true,
  "count": 1,
  "canonicalStillThere": true }

present in raw HTML source: true
no page errors
```

- Old token fully removed (`grep` count: 0) — a stale token left behind alongside the new one is a common cause of failed verification
- Exactly **one** `google-site-verification` tag; Google only reads the first
- Present in the raw HTML source, not JS-injected

## Order of operations

Merge → wait for the Pages deploy to finish → **then** press Verify in Search Console. Verifying before the deploy lands will fail and Google will make you wait before retrying.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)