### PR TITLE
Use the Search Console token for the /u/2 account

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Open a CSV file and sort, resize and search it in your browser. Nothing is uploaded — your file is parsed locally on your own device.">
   <link rel="canonical" href="https://csv-viewer-online.github.io/">
   <!-- Search Console ownership proof. Removing this un-verifies the site. -->
-  <meta name="google-site-verification" content="X0qzkZX4WRevYnA61X4xX3AR9oHcX12rpl2OiykK05k">
+  <meta name="google-site-verification" content="8aw1LwNMMXqelv3hKf9xP8h0Ok7Z02M8rvTzjny7oDw">
   <link rel="icon" href="favicon.svg" type="image/svg+xml">
 
   <meta property="og:type" content="website">


### PR DESCRIPTION
Part of #15.

```diff
-<meta name="google-site-verification" content="X0qzkZX4WRevYnA61X4xX3AR9oHcX12rpl2OiykK05k">
+<meta name="google-site-verification" content="8aw1LwNMMXqelv3hKf9xP8h0Ok7Z02M8rvTzjny7oDw">
```

The property was recreated under a different Google account, which issues its own token.

## Replace, not append

Multiple `google-site-verification` tags **can** coexist — that is how two accounts verify the same site. (An earlier PR of mine claimed Google reads only the first; that was overstated.) This replaces rather than appends because only the `/u/2` account is being verified. If the previous account should stay verified, its tag can be added back alongside this one.

## Verified

```
new token count : 1
old tokens left : 0
total gsc tags  : 1
served          : content="8aw1LwNMMXqelv3hKf9xP8h0Ok7Z02M8rvTzjny7oDw"
head intact     : 6 (canonical + og:image + JSON-LD all still present)
```

Both superseded tokens are fully gone — a stale token lingering beside the new one is a common cause of confusing verification results.

> [!NOTE]
> Merging deploys to production. Wait for the Pages build to finish before pressing Verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)