### PR TITLE
Detect file encoding instead of assuming UTF-8

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const handsontableContainer = document.getElementById('handsontable-container')
 let hot = null
 let allRows = []
 let fields = []
+let encodingLabel = ''
 
 const fmt = (n) => n.toLocaleString('en-US')
 
@@ -43,19 +44,57 @@ function loadDeps() {
   return depsPromise
 }
 
-function readAsText(file) {
+function readAsArrayBuffer(file) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = () => resolve(reader.result)
     reader.onerror = () => reject(reader.error || new Error('could not read file'))
-    reader.readAsText(file)
+    reader.readAsArrayBuffer(file)
   })
 }
 
+// FileReader.readAsText assumes UTF-8, which mangles the Windows-1252 files
+// Excel produces by default. Sniff the encoding instead. TextDecoder strips a
+// leading BOM on its own, so nothing here has to trim one.
+function decodeFile(buf) {
+  const bytes = new Uint8Array(buf)
+  const decode = (encoding, label) => ({ text: new TextDecoder(encoding).decode(buf), encoding: label })
+
+  // A BOM is authoritative.
+  if (bytes[0] === 0xFF && bytes[1] === 0xFE) return decode('utf-16le', 'UTF-16LE')
+  if (bytes[0] === 0xFE && bytes[1] === 0xFF) return decode('utf-16be', 'UTF-16BE')
+  if (bytes[0] === 0xEF && bytes[1] === 0xBB && bytes[2] === 0xBF) return decode('utf-8', 'UTF-8')
+
+  // BOM-less UTF-16 gives away its ASCII text as alternating NUL bytes: at odd
+  // offsets for little-endian, even for big-endian.
+  const probe = bytes.subarray(0, 512)
+  let nul = 0
+  let nulAtEven = 0
+  for (let i = 0; i < probe.length; i++) {
+    if (probe[i] !== 0) continue
+    nul++
+    if (i % 2 === 0) nulAtEven++
+  }
+  if (probe.length > 1 && nul / probe.length > 0.25) {
+    return nulAtEven * 2 > nul ? decode('utf-16be', 'UTF-16BE') : decode('utf-16le', 'UTF-16LE')
+  }
+
+  // Otherwise prefer UTF-8 and fall back only when the bytes are not valid
+  // UTF-8 at all, so genuine UTF-8 files are never second-guessed.
+  try {
+    return { text: new TextDecoder('utf-8', { fatal: true }).decode(buf), encoding: 'UTF-8' }
+  } catch (err) {
+    return decode('windows-1252', 'Windows-1252')
+  }
+}
+
 function setCount(shown) {
-  fileCount.textContent = shown === allRows.length
+  const base = shown === allRows.length
     ? fmt(allRows.length) + ' rows × ' + fields.length + ' cols'
     : fmt(shown) + ' of ' + fmt(allRows.length) + ' rows'
+  // Only worth naming when it is not the expected UTF-8, so a wrong guess is
+  // visible rather than silent.
+  fileCount.textContent = encodingLabel ? base + ' · ' + encodingLabel : base
 }
 
 function applySearch() {
@@ -92,11 +131,13 @@ async function loadFile(file) {
   dropStatus.textContent = 'Opening ' + file.name + '…'
 
   try {
-    const [text] = await Promise.all([readAsText(file), loadDeps()])
-    const parsed = Papa.parse(text, { header: true, skipEmptyLines: true })
+    const [buf] = await Promise.all([readAsArrayBuffer(file), loadDeps()])
+    const decoded = decodeFile(buf)
+    const parsed = Papa.parse(decoded.text, { header: true, skipEmptyLines: true })
 
     allRows = parsed.data
     fields = parsed.meta.fields || []
+    encodingLabel = decoded.encoding === 'UTF-8' ? '' : decoded.encoding
     searchInput.value = ''
 
     document.body.classList.remove('loading', 'no-match')

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?5">
+  <link rel="stylesheet" href="./styles.css?6">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -173,6 +173,6 @@
     </a>
   </aside>
 
-  <script src="./app.js?5"></script>
+  <script src="./app.js?6"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #27. Also fixes the root cause behind #4.

## The bug

`FileReader.readAsText` assumes UTF-8, so **Windows-1252 files rendered as mojibake** — `José` → `Jos?`, `Köln` → `K?ln`. That is the encoding Excel's default *"CSV (Comma delimited)"* export produces on Windows, which makes it one of the likeliest files anyone drops here. BOM-less UTF-16 was worse still, showing a NUL byte between every character.

## The approach

Read an `ArrayBuffer` and sniff, in order:

1. **A BOM is authoritative** — UTF-8, UTF-16LE, UTF-16BE
2. **BOM-less UTF-16** is caught by the alternating NUL bytes its ASCII text produces — odd offsets for little-endian, even for big-endian
3. **Otherwise decode as UTF-8 with `fatal: true`**, falling back to `windows-1252` only when the bytes are not valid UTF-8 at all

Step 3 matters: the fallback is last and conditional, so a genuine UTF-8 file is never second-guessed. `TextDecoder` strips a leading BOM itself so nothing needs trimming, and `windows-1252` is natively supported — **no new dependency**.

A non-UTF-8 result is named in the toolbar chip (`2 rows × 2 cols · Windows-1252`) so a wrong guess is visible rather than silent. UTF-8 shows nothing, since it is what you expect.

## Verified — 10/10, including every case that already worked

```
PASS  ascii.csv           | row1: ["Acme","Berlin"]     | chip: 1 rows × 2 cols
PASS  utf8.csv            | row1: ["José","São Paulo"]  | chip: 2 rows × 2 cols
PASS  utf8_high.csv       | row1: ["José","Köln"]       | chip: 3 rows × 2 cols
PASS  utf8bom.csv         | row1: ["José","Köln"]       | chip: 1 rows × 2 cols
PASS  cp1252.csv          | row1: ["José","Köln"]       | chip: … · Windows-1252
PASS  latin1.csv          | row1: ["François","Genève"] | chip: … · Windows-1252
PASS  utf16bom.csv        | row1: ["José","São Paulo"]  | chip: … · UTF-16LE
PASS  utf16.csv           | row1: ["José","São Paulo"]  | chip: … · UTF-16LE
PASS  utf16be_bom.csv     | row1: ["José","Köln"]       | chip: … · UTF-16BE
PASS  utf16be_nobom.csv   | row1: ["José","Köln"]       | chip: … · UTF-16BE

10/10 passed
empty file handled without crash: true
no page errors
```

The `utf8_high.csv` and `ascii.csv` cases exist specifically to prove the Windows-1252 fallback does **not** over-fire on valid UTF-8 — including CJK and emoji.

## No regressions

```
lazy-load (#13/#21):  handsontable not requested on load · LCP 52ms · CLS 0
                      first open 10 rows · second open no refetch
                      CDN blocked -> error shown -> retry recovers to 10 rows
layout (#11/#12):     outline H1,H2×3,H3×5 · 378 words · no page scroll
                      drop card visible without scrolling · content below fold
                      hero+content hidden when loaded · 10 rows
mobile toolbar:       no h-scroll, height still 49px with the longer chip
```

Cache busters bumped to `?6`.

## Known limit

An 8-bit file whose bytes happen to form valid UTF-8 stays UTF-8 — unavoidable without heuristics that would risk misreading real UTF-8. The visible encoding label is the mitigation; an explicit override (mentioned in #27) would be the full fix if it ever comes up.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)