### PR TITLE
Accept more file types and report parse problems

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,12 +4,65 @@ const searchInput = document.getElementById('search-input')
 const fileName = document.getElementById('file-name')
 const fileCount = document.getElementById('file-count')
 const dropStatus = document.getElementById('drop-status')
+const notice = document.getElementById('notice')
+const noticeText = document.getElementById('notice-text')
 const handsontableContainer = document.getElementById('handsontable-container')
 
 let hot = null
 let allRows = []
 let fields = []
 let encodingLabel = ''
+let delimiterLabel = ''
+
+function showNotice(message, tone) {
+  noticeText.textContent = message
+  notice.classList.toggle('is-error', tone === 'error')
+  notice.hidden = false
+}
+
+function hideNotice() {
+  notice.hidden = true
+  noticeText.textContent = ''
+}
+
+const DELIMITER_NAMES = { '\t': 'tab', ';': 'semicolon', '|': 'pipe', ',': '' }
+
+/** Papa reports problems in parsed.errors, which used to be dropped entirely. */
+function reportParseResult(file, parsed, rows) {
+  const errors = parsed.errors || []
+
+  if (rows.length === 0) {
+    showNotice(
+      `No rows found in ${file.name}. The file may be empty, contain only a header, or not be delimited text at all.`,
+      'error'
+    )
+    return
+  }
+
+  // Row-level problems come first: a malformed file reports MissingQuotes and
+  // TooFewFields alongside UndetectableDelimiter, and the row-level codes say
+  // far more about what is wrong than the delimiter note does.
+  const rowErrors = errors.filter((e) => Number.isInteger(e.row))
+  if (rowErrors.length) {
+    // Papa's row index is 0-based within the data rows
+    const from = Math.min(...rowErrors.map((e) => e.row)) + 1
+    const count = rowErrors.length === 1 ? '1 parse warning' : `${rowErrors.length} parse warnings`
+    showNotice(
+      `${count} in ${file.name}. Data from row ${from} may be incomplete, so what you see may not match the file.`,
+      'warn'
+    )
+    return
+  }
+
+  // Only reached when nothing row-specific was reported, which is what a file
+  // that is not delimited text at all looks like.
+  if (errors.some((e) => e.code === 'UndetectableDelimiter')) {
+    showNotice(
+      `Could not work out the column separator in ${file.name}, so this may not be delimited text. Showing a best guess.`,
+      'error'
+    )
+  }
+}
 
 const fmt = (n) => n.toLocaleString('en-US')
 
@@ -92,9 +145,9 @@ function setCount(shown) {
   const base = shown === allRows.length
     ? fmt(allRows.length) + ' rows × ' + fields.length + ' cols'
     : fmt(shown) + ' of ' + fmt(allRows.length) + ' rows'
-  // Only worth naming when it is not the expected UTF-8, so a wrong guess is
-  // visible rather than silent.
-  fileCount.textContent = encodingLabel ? base + ' · ' + encodingLabel : base
+  // Only name the encoding and separator when they are not the expected
+  // comma/UTF-8, so a wrong guess is visible rather than silent.
+  fileCount.textContent = [base, delimiterLabel, encodingLabel].filter(Boolean).join(' · ')
 }
 
 function applySearch() {
@@ -123,12 +176,13 @@ function render() {
   })
 }
 
-async function loadFile(file) {
+async function loadFile(file, extraWarning) {
   if (!file) return
 
   document.body.classList.remove('load-error')
   document.body.classList.add('loading')
   dropStatus.textContent = 'Opening ' + file.name + '…'
+  hideNotice()
 
   try {
     const [buf] = await Promise.all([readAsArrayBuffer(file), loadDeps()])
@@ -138,6 +192,7 @@ async function loadFile(file) {
     allRows = parsed.data
     fields = parsed.meta.fields || []
     encodingLabel = decoded.encoding === 'UTF-8' ? '' : decoded.encoding
+    delimiterLabel = DELIMITER_NAMES[parsed.meta.delimiter] ?? `“${parsed.meta.delimiter}” separated`
     searchInput.value = ''
 
     document.body.classList.remove('loading', 'no-match')
@@ -145,6 +200,9 @@ async function loadFile(file) {
     dropStatus.textContent = ''
     fileName.textContent = file.name
     setCount(allRows.length)
+    reportParseResult(file, parsed, allRows)
+    // Only surface the lesser warning if nothing more important took the slot
+    if (notice.hidden && extraWarning) showNotice(extraWarning, 'warn')
 
     render()
   } catch (err) {
@@ -228,8 +286,18 @@ window.addEventListener('drop', (e) => {
   e.preventDefault()
   dragCounter = 0
   document.body.classList.remove('drag-over')
-  const file = e.dataTransfer.files[0]
-  if (file && file.name && file.name.toLowerCase().endsWith('.csv')) {
-    loadFile(file)
-  }
+
+  const files = e.dataTransfer.files
+  if (!files || !files.length) return
+
+  // Any file is accepted rather than gated on its extension: the extension is
+  // a poor guide to whether the contents are delimited text, and silently
+  // ignoring a drop — which is what the .csv-only check did to .tsv files —
+  // leaves no way to tell what went wrong. Files that are not delimited text
+  // are reported by reportParseResult instead.
+  loadFile(files[0], files.length > 1
+    ? `Opened ${files[0].name}. Only one file can be viewed at a time.`
+    : '')
 })
+
+document.getElementById('notice-dismiss').addEventListener('click', hideNotice)

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?7">
+  <link rel="stylesheet" href="./styles.css?8">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -72,6 +72,11 @@
     <button class="btn" id="open-btn" type="button">Open<span class="long"> file</span></button>
   </header>
 
+  <p class="notice" id="notice" role="status" aria-live="polite" hidden>
+    <span id="notice-text"></span>
+    <button class="notice-dismiss" id="notice-dismiss" type="button" aria-label="Dismiss">&times;</button>
+  </p>
+
   <main class="work">
     <div class="empty">
       <div class="hero">
@@ -88,9 +93,9 @@
           <polyline points="9 15 12 12 15 15"/>
         </svg>
         <p class="drop-title">Drop your CSV file here</p>
-        <p class="drop-sub">Parsed in your browser — the file is never uploaded.</p>
+        <p class="drop-sub">Also opens .tsv, .tab and .txt. Parsed in your browser — the file is never uploaded.</p>
         <label class="browse-btn" for="input-file">Browse file</label>
-        <input type="file" id="input-file" accept=".csv,text/csv">
+        <input type="file" id="input-file" accept=".csv,.tsv,.tab,.txt,text/csv,text/tab-separated-values,text/plain">
       </div>
 
         <p class="drop-status" id="drop-status" role="status" aria-live="polite"></p>
@@ -173,6 +178,6 @@
     </a>
   </aside>
 
-  <script src="./app.js?7"></script>
+  <script src="./app.js?8"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,9 @@ html, body {
 body {
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--rail);
-  grid-template-rows: 49px minmax(0, 1fr);
+  /* Row 2 holds the parse notice and collapses to nothing while it is hidden,
+     so the grid keeps a definite height either way. */
+  grid-template-rows: 49px auto minmax(0, 1fr);
   background: var(--canvas);
   color: var(--ink);
   font-family: var(--ui);
@@ -96,7 +98,11 @@ body.loaded .divider {
 }
 
 .file-chip .count {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   padding: 2px 7px;
   background: var(--canvas);
   border: 1px solid var(--border);
@@ -186,6 +192,58 @@ body.loaded .search {
 
 .btn:hover {
   background: #0F5AB8;
+}
+
+/* Parse and input feedback. Sits above the work area so it is visible in both
+   the empty state and with a file open. */
+.notice {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin: 0;
+  padding: 9px 12px 9px 14px;
+  background: #FFF8E6;
+  border-bottom: 1px solid #EBD9A6;
+  font-size: 13px;
+  line-height: 1.45;
+  color: #6B4E10;
+}
+
+.notice[hidden] {
+  display: none;
+}
+
+.notice.is-error {
+  background: #FEF2F2;
+  border-bottom-color: #F3C6C6;
+  color: #8C2B22;
+}
+
+#notice-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.notice-dismiss {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 4px;
+  font-family: var(--ui);
+  font-size: 17px;
+  line-height: 1;
+  color: inherit;
+  opacity: 0.6;
+  cursor: pointer;
+}
+
+.notice-dismiss:hover {
+  background: rgba(0, 0, 0, 0.06);
+  opacity: 1;
 }
 
 /* Work area */
@@ -547,7 +605,7 @@ body.no-match .search-empty {
 
   body {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: 49px minmax(0, 1fr) auto;
+    grid-template-rows: 49px auto minmax(0, 1fr) auto;
   }
 
   .toolbar {

--- a/tests/fixtures.mjs
+++ b/tests/fixtures.mjs
@@ -78,14 +78,28 @@ export const FIXTURES = {
     firstRow: ['José', 'São Paulo']
   },
 
-  // Not encoding cases — used by the smoke tests
+  // Not encoding cases — used by the smoke and input specs
   'semicolons.csv': { bytes: Buffer.from('name;city;qty\nJosé;Köln;5\nAcme;Berlin;12\n', 'utf8'), encoding: null },
   'tabs.tsv': { bytes: Buffer.from('name\tcity\tqty\nAcme\tBerlin\t5\nGlobex\tTokyo\t7\n', 'utf8'), encoding: null },
-  'plain.csv': { bytes: Buffer.from(toCsv([HEADER, ...ROWS]), 'utf8'), encoding: null }
+  'pipes.csv': { bytes: Buffer.from('name|city|qty\nAcme|Berlin|5\n', 'utf8'), encoding: null },
+  'plain.csv': { bytes: Buffer.from(toCsv([HEADER, ...ROWS]), 'utf8'), encoding: null },
+
+  // An unterminated quote swallows the rows that follow it
+  'malformed.csv': { bytes: Buffer.from('name,city\n"unterminated quote,Berlin\nok,Paris\n', 'utf8'), encoding: null },
+  'header-only.csv': { bytes: Buffer.from('name,city,qty\n', 'utf8'), encoding: null },
+  // Not delimited text at all — a PNG header. notCsv opts out of the
+  // "must decode to something CSV-shaped" assertion, since being unreadable
+  // is the whole point of this one.
+  'not-a-csv.png': {
+    bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 13, 73, 72, 68, 82]),
+    encoding: null,
+    notCsv: true
+  }
 }
 
 /** Decoding a fixture's bytes must reproduce the text it claims to hold. */
-function assertBytes(name, bytes) {
+function assertBytes(name, bytes, fixture) {
+  if (fixture.notCsv) return
   const enc = {
     'windows-1252.csv': 'windows-1252',
     'latin1.csv': 'windows-1252',
@@ -120,8 +134,9 @@ export async function ensureFixtures() {
   if (dir) return dir
   const base = await mkdtemp(join(tmpdir(), 'csv-viewer-fixtures-'))
   const paths = {}
-  for (const [name, { bytes }] of Object.entries(FIXTURES)) {
-    assertBytes(name, bytes)
+  for (const [name, fixture] of Object.entries(FIXTURES)) {
+    const { bytes } = fixture
+    assertBytes(name, bytes, fixture)
     const file = join(base, name)
     await writeFile(file, bytes)
     // Re-read from disk, so a broken write cannot pass silently

--- a/tests/input.spec.mjs
+++ b/tests/input.spec.mjs
@@ -1,0 +1,161 @@
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { ensureFixtures } from './fixtures.mjs'
+
+let paths
+test.beforeAll(async () => { paths = await ensureFixtures() })
+
+/** Dispatches a real drop event, which is the path that used to fail silently. */
+async function dropFile(page, name, { extra } = {}) {
+  const files = [name, ...(extra ? [extra] : [])].map((f) => ({
+    name: f,
+    data: readFileSync(paths[f]).toString('base64')
+  }))
+  await page.evaluate((files) => {
+    const dt = new DataTransfer()
+    for (const f of files) {
+      const bin = Uint8Array.from(atob(f.data), (c) => c.charCodeAt(0))
+      dt.items.add(new File([bin], f.name))
+    }
+    window.dispatchEvent(new DragEvent('drop', { dataTransfer: dt, bubbles: true, cancelable: true }))
+  }, files)
+}
+
+test.describe('accepted file types', () => {
+  // The bug: the drop handler required a .csv extension, so a .tsv was
+  // discarded with no message at all.
+  test('a .tsv can be dropped, not just picked', async ({ page }) => {
+    await page.goto('/')
+    await dropFile(page, 'tabs.tsv')
+    await expect(page.locator('body')).toHaveClass(/loaded/)
+    await expect(page.locator('#file-name')).toHaveText('tabs.tsv')
+    await expect(page.locator('#handsontable-container .ht_master tbody tr')).toHaveCount(2)
+  })
+
+  test('a .tsv can still be opened through the file picker', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['tabs.tsv'])
+    await expect(page.locator('body')).toHaveClass(/loaded/)
+    await expect(page.locator('#handsontable-container .ht_master tbody tr')).toHaveCount(2)
+  })
+
+  test('the picker offers more than .csv', async ({ page }) => {
+    await page.goto('/')
+    const accept = await page.getAttribute('#input-file', 'accept')
+    for (const ext of ['.csv', '.tsv', '.tab', '.txt']) expect(accept).toContain(ext)
+  })
+
+  test('the detected separator is named when it is not a comma', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['tabs.tsv'])
+    await expect(page.locator('#file-count')).toContainText('tab')
+
+    await page.setInputFiles('#input-file', paths['semicolons.csv'])
+    await expect(page.locator('#file-count')).toContainText('semicolon')
+
+    await page.setInputFiles('#input-file', paths['pipes.csv'])
+    await expect(page.locator('#file-count')).toContainText('pipe')
+  })
+
+  test('a comma-separated file says nothing about its separator', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['plain.csv'])
+    await expect(page.locator('#file-count')).toHaveText('3 rows × 3 cols')
+  })
+
+  test('dropping several files opens one and says so', async ({ page }) => {
+    await page.goto('/')
+    await dropFile(page, 'plain.csv', { extra: 'tabs.tsv' })
+    await expect(page.locator('body')).toHaveClass(/loaded/)
+    await expect(page.locator('#file-name')).toHaveText('plain.csv')
+    await expect(page.locator('#notice')).toContainText('Only one file')
+  })
+})
+
+test.describe('parse problems are reported', () => {
+  // The bug: parsed.errors was discarded, so a mis-parse looked like a clean read.
+  test('a malformed file warns instead of looking fine', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['malformed.csv'])
+    await expect(page.locator('body')).toHaveClass(/loaded/)
+
+    const notice = page.locator('#notice')
+    await expect(notice).toBeVisible()
+    await expect(notice).toContainText('malformed.csv')
+    await expect(notice).toContainText(/parse warning/)
+    // The rows still show — a partial read is usually still useful
+    await expect(page.locator('#handsontable-container')).toBeVisible()
+  })
+
+  test('a header-only file explains itself', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['header-only.csv'])
+    const notice = page.locator('#notice')
+    await expect(notice).toBeVisible()
+    await expect(notice).toContainText('No rows found')
+    await expect(notice).toHaveClass(/is-error/)
+  })
+
+  test('a file that is not delimited text is called out', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['not-a-csv.png'])
+    const notice = page.locator('#notice')
+    await expect(notice).toBeVisible()
+    await expect(notice).toHaveClass(/is-error/)
+    // Whatever the wording, it must not be silent and must not claim success
+    await expect(notice).toContainText('not-a-csv.png')
+  })
+
+  test('a clean file shows no notice at all', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['plain.csv'])
+    await expect(page.locator('body')).toHaveClass(/loaded/)
+    await expect(page.locator('#notice')).toBeHidden()
+  })
+
+  test('the notice can be dismissed and does not persist to the next file', async ({ page }) => {
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['malformed.csv'])
+    await expect(page.locator('#notice')).toBeVisible()
+
+    await page.click('#notice-dismiss')
+    await expect(page.locator('#notice')).toBeHidden()
+
+    // A clean file afterwards must not inherit the warning
+    await page.setInputFiles('#input-file', paths['plain.csv'])
+    await expect(page.locator('#handsontable-container .ht_master tbody tr')).toHaveCount(3)
+    await expect(page.locator('#notice')).toBeHidden()
+  })
+})
+
+test('the notice does not break layout or the grid', async ({ page }) => {
+  for (const [w, h] of [[1440, 900], [390, 844]]) {
+    await page.setViewportSize({ width: w, height: h })
+    await page.goto('/')
+    await page.setInputFiles('#input-file', paths['malformed.csv'])
+    await expect(page.locator('#notice')).toBeVisible()
+
+    // No page-level scrollbars, and the grid still has room to render
+    expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)).toBe(false)
+    expect(await page.evaluate(() => document.documentElement.scrollHeight > document.documentElement.clientHeight)).toBe(false)
+    const box = await page.locator('#handsontable-container').boundingBox()
+    expect(box.height).toBeGreaterThan(50)
+  }
+})
+
+test('the toolbar survives a long chip at 390px', async ({ page }) => {
+  // tab-separated AND Windows-1252 makes the longest chip the app can produce
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/')
+  await page.setInputFiles('#input-file', {
+    name: 'wide.tsv',
+    mimeType: 'text/tab-separated-values',
+    buffer: Buffer.from('name\tcity\nJos\xe9\tK\xf6ln\n', 'latin1')
+  })
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+  await expect(page.locator('#file-count')).toContainText('Windows-1252')
+
+  expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)).toBe(false)
+  await expect(page.locator('#open-btn')).toBeVisible()
+  expect(await page.evaluate(() => Math.round(document.querySelector('.toolbar').getBoundingClientRect().height))).toBe(49)
+})


### PR DESCRIPTION
Closes #28, closes #29. Two bugs with one shared cause: the app decided what it could open from the file **extension**, then said **nothing** when anything went wrong.

## #28 — dropping a `.tsv` did nothing at all

The drop handler required a `.csv` extension and discarded everything else silently, so the primary interaction failed on a file type the FAQ claims to support.

The extension gate is **gone**. Any dropped file is attempted, because the extension is a poor guide to whether the contents are delimited text, and a silent no-op leaves no way to tell what happened. The picker's `accept` list gains `.tsv`, `.tab` and `.txt` so those files are visible without switching to *All Files*.

Dropping several files now opens the first and says so, rather than ignoring the rest quietly.

## #29 — a mis-parse looked like a clean read

`parsed.errors` was discarded. An unterminated quote collapsed three lines into one cell while the toolbar reported `1 rows × 2 cols` as if nothing were wrong.

A dismissible notice now reports three distinct cases:

| Case | Message |
|---|---|
| Row-level problems | `2 parse warnings in file.csv. Data from row 1 may be incomplete…` |
| No data rows | `No rows found in file.csv. The file may be empty, contain only a header…` |
| No detectable separator | `Could not work out the column separator in file.png…` |

### Ordering was checked, not guessed

I dumped PapaParse's real output before deciding priority:

```
malformed.csv | rows 1 | errors: MissingQuotes(row 1), UndetectableDelimiter, TooFewFields(row 0)
header-only   | rows 0 | errors: []
PNG bytes     | rows 2 | errors: UndetectableDelimiter
clean         | rows 1 | errors: []
```

A malformed CSV reports **all three** codes, and the row-level ones say far more about the problem — so row-level errors are checked **before** `UndetectableDelimiter`, and only a file with no row-specific errors at all is treated as "not delimited text". My first attempt had this backwards and reported a malformed CSV as an undetectable separator; the test caught it.

Note `header-only.csv` produces **no errors at all**, so the zero-rows check is what catches it — errors alone would have missed it.

## Layout

The notice sits in its own body-grid row, so it is visible in the empty state *and* with a file open, and the row collapses to nothing while hidden so the grid keeps a definite height.

The detected separator is now named in the chip when it is not a comma (`1 rows × 3 cols · tab`), which makes the FAQ's auto-detection claim verifiable rather than asserted. The chip truncates rather than pushing the toolbar around when it carries both a separator and an encoding.

## Verified — 50 tests, 13.2s

**13 new tests**, including a real `DragEvent` drop for the `.tsv` case, so the path that actually failed is covered rather than only the picker path:

- `.tsv` opens by **drop** and by picker; `accept` offers all four extensions
- separator named for tab/semicolon/pipe; a comma file says nothing extra
- multi-file drop opens one and reports it
- malformed → warning with row number, rows still shown
- header-only → error notice
- PNG → error notice naming the file
- clean file → **no notice at all**
- notice dismisses, and does not carry over to the next file
- notice breaks neither layout nor grid height at 1440 and 390
- toolbar still 49px with the longest possible chip (tab + Windows-1252) at 390px

All 37 pre-existing tests still pass.

Cache busters bumped to `?8`.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)