### PR TITLE
Place grid rows explicitly so the page fills the viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?8">
+  <link rel="stylesheet" href="./styles.css?9">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -93,7 +93,7 @@
           <polyline points="9 15 12 12 15 15"/>
         </svg>
         <p class="drop-title">Drop your CSV file here</p>
-        <p class="drop-sub">Also opens .tsv, .tab and .txt. Parsed in your browser — the file is never uploaded.</p>
+        <p class="drop-sub">Also opens .tsv, .tab and .txt.<br>Parsed in your browser — the file is never uploaded.</p>
         <label class="browse-btn" for="input-file">Browse file</label>
         <input type="file" id="input-file" accept=".csv,.tsv,.tab,.txt,text/csv,text/tab-separated-values,text/plain">
       </div>
@@ -178,6 +178,6 @@
     </a>
   </aside>
 
-  <script src="./app.js?8"></script>
+  <script src="./app.js?9"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -43,7 +43,12 @@ body {
 
 /* Toolbar — present both before and after a file is open, so the page is
    never left without an identity. */
+/* Every row is placed explicitly. The notice is display:none while hidden,
+   which removes it as a grid item — with auto placement that let .work and
+   .rail fall into the notice's auto-sized row and shrink to their content
+   instead of filling the viewport. */
 .toolbar {
+  grid-row: 1;
   grid-column: 1 / -1;
   display: flex;
   align-items: center;
@@ -197,6 +202,7 @@ body.loaded .search {
 /* Parse and input feedback. Sits above the work area so it is visible in both
    the empty state and with a file open. */
 .notice {
+  grid-row: 2;
   grid-column: 1 / -1;
   display: flex;
   align-items: flex-start;
@@ -248,6 +254,8 @@ body.loaded .search {
 
 /* Work area */
 .work {
+  grid-row: 3;
+  grid-column: 1;
   position: relative;
   min-width: 0;
   min-height: 0;
@@ -527,6 +535,8 @@ body.no-match .search-empty {
 /* Sponsor rail — one uniform frame per tile, so a loud logo can't set the
    tone of the whole page. */
 .rail {
+  grid-row: 3;
+  grid-column: 2;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -655,6 +665,9 @@ body.no-match .search-empty {
   }
 
   .rail {
+    /* Single column here, so the rail moves below the work area */
+    grid-row: 4;
+    grid-column: 1;
     flex-direction: row;
     align-items: center;
     padding: 10px;

--- a/tests/smoke.spec.mjs
+++ b/tests/smoke.spec.mjs
@@ -33,6 +33,54 @@ test.describe('empty state', () => {
       expect(errors).toEqual([])
     })
 
+    // A hidden notice used to leave .work and .rail auto-placed into its
+    // auto-sized row, so the app filled only its content height and left the
+    // bottom of the viewport blank. Nothing asserted full height before.
+    test(`${label}: the layout fills the viewport height`, async ({ page }) => {
+      await page.setViewportSize(viewport)
+      await page.goto('/')
+
+      // Layout-agnostic: the rail is beside .work on desktop and below it on
+      // mobile, so assert on whatever sits lowest rather than a fixed element.
+      const layout = await page.evaluate(() => {
+        const visible = [...document.body.children].filter((el) => getComputedStyle(el).display !== 'none')
+        const lowest = Math.max(...visible.map((el) => el.getBoundingClientRect().bottom))
+        const rows = getComputedStyle(document.body).gridTemplateRows.split(' ').map(parseFloat)
+        return {
+          lowest: Math.round(lowest),
+          unusedTrack: Math.round(rows.reduce((a, b) => a + b, 0) - lowest),
+          railBottom: Math.round(document.querySelector('.rail').getBoundingClientRect().bottom)
+        }
+      })
+      expect(layout.lowest, 'the page must reach the bottom of the viewport').toBe(viewport.height)
+      expect(layout.unusedTrack, 'no grid row may sit unused below the content').toBe(0)
+      expect(layout.railBottom, 'the sponsor rail must reach the bottom').toBe(viewport.height)
+    })
+
+    test(`${label}: still fills the viewport with a file open and a notice showing`, async ({ page }) => {
+      await page.setViewportSize(viewport)
+      await page.goto('/')
+      await page.setInputFiles('#input-file', paths['malformed.csv'])
+      await expect(page.locator('#notice')).toBeVisible()
+
+      const rail = await page.locator('.rail').boundingBox()
+      expect(Math.round(rail.y + rail.height), 'the rail must still reach the bottom').toBe(viewport.height)
+
+      // The grid keeps real height even with the notice taking a row
+      const grid = await page.locator('#handsontable-container').boundingBox()
+      expect(grid.height).toBeGreaterThan(100)
+
+      // and the notice must sit between the toolbar and the work area
+      const gap = await page.evaluate(() => {
+        const r = (s) => document.querySelector(s).getBoundingClientRect()
+        return {
+          afterToolbar: Math.round(r('#notice').top - r('.toolbar').bottom),
+          beforeWork: Math.round(r('.work').top - r('#notice').bottom)
+        }
+      })
+      expect(gap).toEqual({ afterToolbar: 0, beforeWork: 0 })
+    })
+
     test(`${label}: no horizontal overflow outside the sponsor rail`, async ({ page }) => {
       await page.setViewportSize(viewport)
       await page.goto('/')


### PR DESCRIPTION
Fixes the regression from #38: the page occupied only its content height, leaving the lower half of the viewport blank.

## Cause

`.notice` is `display: none` while hidden, which removes it as a **grid item**. With auto placement, `.work` and `.rail` then landed in the notice's `auto`-sized row instead of the `1fr` row below it — so both shrank to their content, and the `1fr` track sat empty underneath.

Measured on production before the fix:

```
grid-template-rows: 49px 480.781px 370.219px    ← .work in row 2 (auto), row 3 unused
work:  top 49  bottom 530   (viewport 900)
rail:  top 49  bottom 530
```

After:

```
grid-template-rows: 49px 0px 851px              ← .work in row 3 (1fr)
work bottom 900, rail bottom 900  (viewport 900)
```

## Fix

Every row is assigned explicitly — `toolbar: 1`, `notice: 2`, `work: 3`, `rail: 3` — so hiding the notice cannot shift anything. On mobile the rail moves to row 4, where it sits below the work area rather than beside it.

## Why the suite missed it

This is the part worth noting. The existing tests asserted:

- no horizontal or vertical overflow — **still true** at half height
- the drop card is reachable without scrolling — **still true**
- the grid has height > 50px when loaded — **still true**

Nothing asserted the app *fills* the viewport, so a half-height layout passed cleanly.

Two new tests now do, at all three widths:

- the lowest visible element reaches the bottom of the viewport
- no grid track is left unused below the content
- the rail reaches the bottom
- and the same with a file open and the notice showing, plus that the notice sits flush between the toolbar and the work area

They check **whichever element sits lowest** rather than a fixed one, so they hold for both the side-by-side desktop layout and the stacked mobile layout — my first version asserted `.work` reached the bottom, which is false on mobile by design.

**Verified they catch the bug:** run against the broken stylesheet, the new tests fail; with the fix, 56/56 pass.

## Also

Splits the drop-zone subtitle onto two lines, as requested.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)