### PR TITLE
Stop the "How it works" cue from hijacking the first view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ playwright-report/
 blob-report/
 .DS_Store
 *.swp
+
+# Files the app itself downloads, if they land in the repo
+*-export.csv
+*-export.json

--- a/app.js
+++ b/app.js
@@ -219,6 +219,37 @@ async function loadFile(file, extraWarning) {
   }
 }
 
+/* ── The "How it works" cue ────────────────────────────────────────────────
+   It used to be a plain #about link, which wrote the fragment into the URL.
+   Any later return to that URL — history, a bookmark, tab restore, an
+   address-bar suggestion — then opened on the prose instead of the tool. */
+
+const emptyPane = document.querySelector('.empty')
+const aboutSection = document.getElementById('about')
+
+document.querySelector('.scroll-cue').addEventListener('click', (e) => {
+  e.preventDefault()
+  aboutSection.scrollIntoView({
+    behavior: matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+    block: 'start'
+  })
+})
+
+// Drop a stale fragment so an already-bookmarked #about cannot keep hijacking
+// the first view. The drop zone is the point of the page; it always comes first.
+function clearStaleFragment() {
+  if (!location.hash) return
+  history.replaceState(null, '', location.pathname + location.search)
+  // WebKit applies the fragment scroll after this script runs, so reset on the
+  // next frame as well as now.
+  emptyPane.scrollTop = 0
+  requestAnimationFrame(() => { emptyPane.scrollTop = 0 })
+}
+
+clearStaleFragment()
+// A fragment can also arrive mid-session, e.g. via the back button
+window.addEventListener('hashchange', clearStaleFragment)
+
 /* ── Download ──────────────────────────────────────────────────────────────
    What downloads is what is on screen: rows are read by visual index, so the
    chosen sort order, the active search filter and any cell edits all carry

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?10">
+  <link rel="stylesheet" href="./styles.css?11">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -190,6 +190,6 @@
     </a>
   </aside>
 
-  <script src="./app.js?10"></script>
+  <script src="./app.js?11"></script>
 </body>
 </html>

--- a/tests/first-view.spec.mjs
+++ b/tests/first-view.spec.mjs
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+// The drop zone is the point of the page, so it must be what you see first —
+// on a plain load, and on a return visit to a URL that still carries #about.
+async function firstView(page) {
+  return page.evaluate(() => {
+    const inView = (el) => {
+      const r = el.getBoundingClientRect()
+      return r.top >= 0 && r.top < window.innerHeight
+    }
+    return {
+      hash: location.hash,
+      paneScrollTop: Math.round(document.querySelector('.empty').scrollTop),
+      dropZoneInView: inView(document.getElementById('drop-zone')),
+      h1InView: inView(document.querySelector('h1')),
+      proseInView: inView(document.querySelector('.content h2'))
+    }
+  })
+}
+
+test('a plain load opens on the drop zone', async ({ page }) => {
+  await page.goto('/')
+  expect(await firstView(page)).toMatchObject({
+    hash: '', paneScrollTop: 0, dropZoneInView: true, h1InView: true
+  })
+})
+
+test('the cue scrolls to the prose without putting a fragment in the URL', async ({ page }) => {
+  await page.goto('/')
+  await page.click('.scroll-cue')
+  await page.waitForTimeout(700)
+
+  const after = await firstView(page)
+  expect(after.proseInView, 'the prose must actually be reached').toBe(true)
+  // The whole cause of the bug: a fragment that outlives the visit
+  expect(after.hash, 'tapping the cue must not change the URL').toBe('')
+  expect(page.url()).not.toContain('#')
+})
+
+test('returning to a URL that still has #about opens on the drop zone', async ({ page }) => {
+  await page.goto('/#about')
+  await page.waitForTimeout(500)
+
+  const view = await firstView(page)
+  expect(view.dropZoneInView, 'a stale #about must not hijack the first view').toBe(true)
+  expect(view.paneScrollTop).toBe(0)
+  expect(view.hash, 'the stale fragment should be cleaned out of the URL').toBe('')
+})
+
+test('the prose is still reachable by scrolling', async ({ page }) => {
+  await page.goto('/')
+  await page.evaluate(() => document.querySelector('.empty').scrollTo(0, 99999))
+  await page.waitForTimeout(300)
+  await expect(page.locator('.content h2').first()).toBeVisible()
+  await expect(page.locator('#drop-zone')).not.toBeInViewport()
+})


### PR DESCRIPTION
Fixes the iPhone report: opening the site showed the prose, with the drop zone scrolled off the top.

## Cause

The cue was a plain `<a href="#about">`, so **tapping it wrote the fragment into the URL**. Any later return to that URL — history, a bookmark, tab restore, an address-bar suggestion — reopened the page scrolled to the article.

Reproduced in WebKit with an iPhone profile:

```
plain load          hash ""        dropZoneTop  219   first heading "CSV Viewer Online"
after tapping cue   hash "#about"  dropZoneTop -331   first heading "Read a CSV without…"
revisit /#about     hash "#about"  dropZoneTop -331   first heading "Read a CSV without…"
```

That last line is the reported screenshot.

## Fix

- The cue scrolls **programmatically** and leaves the URL untouched, so the fragment is never created in the first place.
- A fragment arriving any other way is dropped with `replaceState` and the pane reset to the top. The drop zone is the point of the page; it always comes first.
- **WebKit applies the fragment scroll *after* the script runs**, so the reset repeats on the next frame — resetting only once was not enough there.
- `hashchange` is handled too, for a fragment arriving mid-session via the back button.
- The smooth scroll respects `prefers-reduced-motion`.

## Verified in WebKit on an iPhone profile

```
A) fresh load, plain URL          hash ""  scrollTop 0    drop zone visible ✅
B) fresh load of /#about          hash ""  scrollTop 0    drop zone visible ✅  ← the bug
C) tap the cue                    hash ""  scrollTop 550  reaches the prose  ✅
D) same-session hash (back)       hash ""  scrollTop 0    drop zone visible ✅
```

Four new tests cover all of this, including that tapping the cue leaves no `#` in the URL. 73 passing in total.

## A note on my earlier diagnosis

My first WebKit check appeared to show the fix failing. That was a test artifact: navigating `/` → `/#about` in the same page is a **same-document** navigation, so the document never reloads and `app.js` never re-runs. Forcing a genuine fresh load showed it working. Worth recording, since it is an easy way to mislead yourself when testing fragment behaviour.

## Also

Adds `*-export.csv` / `*-export.json` to `.gitignore`. A `windows-1252-export.csv` from testing the new download feature had landed in `images/` and was about to be committed; the app now generates files with that name by design, so they are ignored from here on.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)