### PR TITLE
Open a sponsor enquiry dialog instead of a bare mailto

### DIFF
--- a/app.js
+++ b/app.js
@@ -219,6 +219,35 @@ async function loadFile(file, extraWarning) {
   }
 }
 
+/* ── Sponsor enquiry dialog ────────────────────────────────────────────────
+   Replaces a bare mailto: on the "Your ad here" tile, which fired the mail
+   client with no idea what was being offered. Native <dialog>, so focus
+   trapping, Escape and the backdrop come from the browser. */
+
+const sponsorDialog = document.getElementById('sponsor-dialog')
+const copyEmailBtn = document.getElementById('copy-email')
+
+document.getElementById('sponsor-cta').addEventListener('click', () => {
+  sponsorDialog.showModal()
+})
+
+document.getElementById('sponsor-dialog-close').addEventListener('click', () => {
+  sponsorDialog.close()
+})
+
+// Clicking the backdrop closes it. The dialog's own box is the only child that
+// receives clicks, so a click landing on <dialog> itself is a backdrop click.
+sponsorDialog.addEventListener('click', (e) => {
+  if (e.target === sponsorDialog) sponsorDialog.close()
+})
+
+copyEmailBtn.addEventListener('click', async () => {
+  const address = document.getElementById('sponsor-email').textContent.trim()
+  const copied = await copyText(address)
+  copyEmailBtn.textContent = copied ? 'Copied' : 'Press ⌘C'
+  setTimeout(() => { copyEmailBtn.textContent = 'Copy' }, 2000)
+})
+
 /* ── Download ──────────────────────────────────────────────────────────────
    What downloads is what is on screen: rows are read by visual index, so the
    chosen sort order, the active search filter and any cell edits all carry

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, edit, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?11">
+  <link rel="stylesheet" href="./styles.css?12">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -157,10 +157,10 @@
   <aside class="rail" aria-label="Sponsors">
     <p class="rail-h">Sponsors</p>
 
-    <a class="tile cta" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">
+    <button class="tile cta" id="sponsor-cta" type="button" aria-haspopup="dialog">
       <b>Your ad here</b>
       <span>~50k visitors monthly<br>$19/month</span>
-    </a>
+    </button>
 
     <a class="tile" href="https://venopay.xyz/" target="_blank" rel="noopener">
       <img src="/images/venopay.png" alt=""> VenoPay
@@ -191,6 +191,37 @@
     </a>
   </aside>
 
-  <script src="./app.js?11"></script>
+  <dialog class="sponsor-dialog" id="sponsor-dialog" aria-labelledby="sponsor-dialog-title">
+    <button class="dialog-close" id="sponsor-dialog-close" type="button" aria-label="Close">&times;</button>
+
+    <h2 id="sponsor-dialog-title">Advertise here</h2>
+    <p class="dialog-lede">Your logo and name in the sidebar — visible on every visit, and while someone is working with their file.</p>
+
+    <dl class="stats">
+      <div>
+        <dt>Visitors</dt>
+        <dd>~50,000<span>per month</span></dd>
+      </div>
+      <div>
+        <dt>Google</dt>
+        <dd>#2<span>for “CSV Viewer”</span></dd>
+      </div>
+      <div>
+        <dt>Price</dt>
+        <dd>$19<span>per month</span></dd>
+      </div>
+    </dl>
+
+    <p class="dialog-note">Mostly developers, analysts and people wrangling exports. No tracking, no popups, nothing that gets between a visitor and their file.</p>
+
+    <p class="dialog-label">Get in touch</p>
+    <div class="email-row">
+      <code id="sponsor-email">csv-viewer-online@tianon.anonaddy.me</code>
+      <button class="btn quiet" id="copy-email" type="button">Copy</button>
+    </div>
+    <a class="btn dialog-mail" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">Open in mail app</a>
+  </dialog>
+
+  <script src="./app.js?12"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -666,14 +666,21 @@ body.no-match .search-empty {
   object-fit: contain;
 }
 
+/* A <button>, not a link — it opens the enquiry dialog, so it needs the
+   element defaults reset back to how the sibling tiles look. */
 .tile.cta {
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
+  width: 100%;
   padding: 10px 11px;
   background: var(--action-soft);
   border: 1px dashed var(--action);
+  border-radius: 7px;
+  font-family: var(--ui);
+  text-align: left;
   color: var(--action);
+  cursor: pointer;
 }
 
 .tile.cta b {
@@ -686,6 +693,140 @@ body.no-match .search-empty {
   font-weight: 600;
   line-height: 1.45;
   color: #3D6EA8;
+}
+
+/* Sponsor enquiry dialog. Native <dialog> so focus trapping, Escape and the
+   backdrop come from the browser rather than hand-rolled JS. */
+.sponsor-dialog {
+  width: min(430px, calc(100vw - 32px));
+  padding: 26px 26px 24px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 32px 70px -30px rgba(22, 24, 29, 0.45);
+  color: var(--ink);
+  font-family: var(--ui);
+}
+
+.sponsor-dialog::backdrop {
+  background: rgba(16, 22, 33, 0.42);
+}
+
+.dialog-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 6px;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.dialog-close:hover {
+  background: var(--chrome);
+  color: var(--ink);
+}
+
+.sponsor-dialog h2 {
+  margin: 0 0 6px;
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.dialog-lede {
+  margin: 0 0 20px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--prose);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin: 0 0 18px;
+}
+
+.stats > div {
+  padding: 11px 10px;
+  background: var(--chrome);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  text-align: center;
+}
+
+.stats dt {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.stats dd {
+  margin: 4px 0 0;
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--action);
+}
+
+.stats dd span {
+  display: block;
+  margin-top: 2px;
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0;
+  color: var(--muted);
+}
+
+.dialog-note {
+  margin: 0 0 20px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+.dialog-label {
+  margin: 0 0 7px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.email-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.email-row code {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 8px 10px;
+  background: var(--chrome);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: var(--data);
+  font-size: 12px;
+  overflow: auto;
+  white-space: nowrap;
+}
+
+.dialog-mail {
+  display: block;
+  text-align: center;
+  line-height: 30px;
+  text-decoration: none;
 }
 
 @media (max-width: 820px) {
@@ -766,6 +907,7 @@ body.no-match .search-empty {
   }
 
   .tile.cta {
+    width: auto;
     flex-direction: row;
     align-items: center;
     gap: 8px;

--- a/tests/sponsor-dialog.spec.mjs
+++ b/tests/sponsor-dialog.spec.mjs
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test'
+import { ensureFixtures } from './fixtures.mjs'
+
+let paths
+test.beforeAll(async () => { paths = await ensureFixtures() })
+
+const dialog = (page) => page.locator('#sponsor-dialog')
+
+test('the CTA is a button, not a mailto link', async ({ page }) => {
+  await page.goto('/')
+  const cta = page.locator('#sponsor-cta')
+  await expect(cta).toBeVisible()
+  expect(await cta.evaluate((el) => el.tagName)).toBe('BUTTON')
+  await expect(cta).toHaveAttribute('aria-haspopup', 'dialog')
+
+  // No mailto should fire from the rail itself any more
+  const railMailtos = await page.locator('.rail a[href^="mailto:"]').count()
+  expect(railMailtos).toBe(0)
+})
+
+test('clicking it opens a dialog with the stats and the address', async ({ page }) => {
+  await page.goto('/')
+  await expect(dialog(page)).toBeHidden()
+
+  await page.click('#sponsor-cta')
+  await expect(dialog(page)).toBeVisible()
+
+  const text = await dialog(page).innerText()
+  expect(text).toContain('~50,000')
+  expect(text).toContain('#2')
+  expect(text).toContain('$19')
+  expect(text).toContain('CSV Viewer')
+
+  await expect(page.locator('#sponsor-email')).toHaveText('csv-viewer-online@tianon.anonaddy.me')
+  // A mailto is still offered inside the dialog, as a secondary route
+  await expect(page.locator('.dialog-mail')).toHaveAttribute('href', /^mailto:csv-viewer-online@/)
+})
+
+test('it is a modal, so the page behind is inert', async ({ page }) => {
+  await page.goto('/')
+  await page.click('#sponsor-cta')
+  expect(await dialog(page).evaluate((d) => d.matches(':modal'))).toBe(true)
+})
+
+test.describe('closing', () => {
+  test('Escape closes it', async ({ page }) => {
+    await page.goto('/')
+    await page.click('#sponsor-cta')
+    await expect(dialog(page)).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(dialog(page)).toBeHidden()
+  })
+
+  test('the close button closes it', async ({ page }) => {
+    await page.goto('/')
+    await page.click('#sponsor-cta')
+    await page.click('#sponsor-dialog-close')
+    await expect(dialog(page)).toBeHidden()
+  })
+
+  test('clicking the backdrop closes it, clicking inside does not', async ({ page }) => {
+    await page.goto('/')
+    await page.click('#sponsor-cta')
+
+    // Inside first: the dialog must survive a click on its own content
+    await page.locator('#sponsor-dialog-title').click()
+    await expect(dialog(page)).toBeVisible()
+
+    // Then the backdrop, at a point outside the dialog's box
+    const box = await dialog(page).boundingBox()
+    await page.mouse.click(Math.max(4, box.x / 2), Math.max(4, box.y / 2))
+    await expect(dialog(page)).toBeHidden()
+  })
+
+  test('focus returns to the CTA after closing', async ({ page }) => {
+    await page.goto('/')
+    await page.click('#sponsor-cta')
+    await page.keyboard.press('Escape')
+    await expect(page.locator('#sponsor-cta')).toBeFocused()
+  })
+})
+
+test.describe('copying the address', () => {
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] })
+
+  test('the copy button puts the address on the clipboard', async ({ page }) => {
+    await page.goto('/')
+    await page.click('#sponsor-cta')
+    await page.click('#copy-email')
+
+    await expect(page.locator('#copy-email')).toHaveText('Copied')
+    expect(await page.evaluate(() => navigator.clipboard.readText()))
+      .toBe('csv-viewer-online@tianon.anonaddy.me')
+
+    // and it goes back to its resting label
+    await expect(page.locator('#copy-email')).toHaveText('Copy', { timeout: 4000 })
+  })
+})
+
+test('it still works with a file open', async ({ page }) => {
+  await page.goto('/')
+  await page.setInputFiles('#input-file', paths['plain.csv'])
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+
+  await page.click('#sponsor-cta')
+  await expect(dialog(page)).toBeVisible()
+  await page.keyboard.press('Escape')
+  // Escape must not also wipe the search or otherwise disturb the grid
+  await expect(page.locator('#handsontable-container .ht_master tbody tr')).toHaveCount(3)
+})
+
+test('the CTA still sits among 8 tiles at mobile width', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/')
+  await expect(page.locator('.rail .tile')).toHaveCount(8)
+
+  await page.click('#sponsor-cta')
+  await expect(dialog(page)).toBeVisible()
+  const box = await dialog(page).boundingBox()
+  expect(box.width).toBeLessThanOrEqual(390)
+  expect(box.x).toBeGreaterThanOrEqual(0)
+})


### PR DESCRIPTION
The "Your ad here" tile fired the mail client immediately — asking someone to compose an email before they'd been told what was on offer, and doing nothing at all for anyone without a mail client configured.

## What it does now

Clicking it opens a dialog with the numbers an advertiser actually wants:

```
┌──────────────────────────────────────────────┐
│  Advertise here                          ×   │
│  Your logo and name in the sidebar —         │
│  visible on every visit, and while someone   │
│  is working with their file.                 │
│                                              │
│  ┌ VISITORS ┐ ┌  GOOGLE  ┐ ┌  PRICE  ┐       │
│  │ ~50,000  │ │    #2    │ │   $19   │       │
│  │per month │ │for "CSV  │ │per month│       │
│  └──────────┘ │ Viewer"  │ └─────────┘       │
│               └──────────┘                   │
│                                              │
│  Mostly developers, analysts and people      │
│  wrangling exports. No tracking, no popups…  │
│                                              │
│  GET IN TOUCH                                │
│  [csv-viewer-online@tianon…] [ Copy ]        │
│  [        Open in mail app         ]         │
└──────────────────────────────────────────────┘
```

The address is selectable text with a copy button; the mailto is still there as a **secondary** route rather than the only one.

## Built on native `<dialog>`

`showModal()` gives focus trapping, Escape, focus restoration and the backdrop from the browser rather than hand-rolled JS — less code and better behaviour than a div-based modal. Clicking the backdrop closes it; clicking the dialog's own content does not.

The copy button reuses the clipboard helper written for the export menu, so it inherits the selection-based fallback for browsers that block the async API.

The tile becomes a `<button>`, with its element defaults reset back to matching the sibling tiles.

## Verified — 85 tests

**11 new**: the CTA is a `<button>` and no `mailto:` remains in the rail, the dialog reports `:modal`, all three close routes (Escape / close button / backdrop), that clicking *inside* does **not** close it, focus returning to the tile, the clipboard contents, that it works with a file open without Escape disturbing the grid, and that it fits within 390px.

Cache busters bumped to `?12`.

> [!NOTE]
> The `#2 on Google` figure is hard-coded in the markup. Rankings move, and this one is now a public claim an advertiser can check — worth a glance now and then, or softening to "top 3" if you'd rather not maintain it.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)