### PR TITLE
Rewrite the README to match what the site actually is

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,106 @@
-# CSV Viewer Online
-### [https://csv-viewer-online.github.io/](https://csv-viewer-online.github.io/)
+# CSV Viewer &amp; Editor Online
 
-### Used plugins:
+### [csv-viewer-online.github.io](https://csv-viewer-online.github.io/)
 
-- [PapaParse](https://github.com/mholt/PapaParse) for parsing CSV
-- [handsontable](https://github.com/handsontable/handsontable) for showing the parsed data as a spreadsheet
+Open a CSV file, edit it, sort and search it — in your browser. Nothing is
+uploaded: the file is read straight from disk by the page you already have
+open, parsed in memory, and drawn on screen. No account, nothing to delete
+afterwards, and no upload request carrying your data.
+
+## What it does
+
+- **Commas, semicolons, tabs and pipes** — the separator is detected
+  automatically, so European semicolon exports and tab-separated files open
+  without changing a setting. A non-comma separator is named in the toolbar.
+- **Encodings** — UTF-8, UTF-16 (with or without a BOM, either endianness) and
+  Windows-1252, which is what Excel's default *CSV (Comma delimited)* export
+  produces. A non-UTF-8 file says which encoding was detected, so a wrong guess
+  is visible rather than silent.
+- **Quoted fields** — values in quotes may contain commas, escaped quotes and
+  line breaks.
+- **Sorting, column resizing and search** — press <kbd>/</kbd> to jump to the
+  search box.
+- **Editing** — type into any cell.
+- **Download** — save what is on screen as CSV or JSON, or copy it to the
+  clipboard. The sort order, the active search filter and your edits all carry
+  through, and the separator the file arrived with is preserved. Your original
+  file is never touched.
+- **Honest parsing** — malformed rows, files with no data rows, and files that
+  are not delimited text at all are reported rather than quietly mis-rendered.
+
+Files are opened by drag-and-drop or the file picker. `.csv`, `.tsv`, `.tab`
+and `.txt` are offered in the picker, and any dropped file is attempted.
+
+## How it is built
+
+Plain HTML, CSS and JavaScript with **no build step**. The whole site is three
+files plus static assets:
+
+```
+index.html      markup and <head>
+styles.css      all styling
+app.js          parsing, the grid, search, export
+```
+
+Two libraries do the heavy lifting, both loaded from a CDN:
+
+- [PapaParse](https://github.com/mholt/PapaParse) — CSV parsing
+- [Handsontable](https://github.com/handsontable/handsontable) — the grid
+
+They are **fetched on first file open rather than on page load**. Handsontable
+alone is ~1.6 MB, which was 92% of the page weight and wasted on every visit
+where nobody opened a file. Deferring it takes the initial load from ~1,826 KB
+to ~106 KB.
+
+## Development
+
+There is nothing to compile. Serve the directory and open it:
+
+```sh
+bun run serve      # http://localhost:4319
+```
+
+Any static server works — `serve.mjs` only exists so the test suite has one
+with no dependencies.
+
+### Tests
+
+[Playwright](https://playwright.dev/) against a real browser, since most of
+what could break here is browser behaviour — `FileReader` encodings,
+drag-and-drop, the clipboard, grid rendering.
+
+```sh
+bun install
+bunx playwright install chromium
+bun run test          # 85 tests
+bun run test:headed   # watch them run
+bun run test:ui       # interactive
+```
+
+| Spec | Covers |
+| --- | --- |
+| `encoding.spec.mjs` | every supported encoding, and that valid UTF-8 is never misread |
+| `input.spec.mjs` | accepted file types, and parse problems being reported |
+| `export.spec.mjs` | CSV/JSON download, clipboard, filter and sort carrying through |
+| `smoke.spec.mjs` | layout at three widths, lazy loading, search, head tags, static files |
+| `sponsor-dialog.spec.mjs` | the enquiry dialog |
+| `branding.spec.mjs` | naming, and that "CSV Viewer" stays the leading phrase |
+
+Fixtures are generated into a temp directory rather than committed, and the
+suite asserts their bytes really are in the encoding they claim — a fixture
+that silently stopped being Windows-1252 would otherwise pass while the bug
+came back.
+
+CI runs the suite on every pull request and push to `main`
+(`.github/workflows/test.yml`). GitHub Pages deploys from `main`, so a merge
+goes straight to production.
+
+## Sponsors
+
+The tiles in the sidebar are paid placements at **$19/month** — a logo and
+name, shown on every visit and while a file is open. No tracking and no
+popups. Click **Your ad here** on the site for details, or email
+[csv-viewer-online@tianon.anonaddy.me](mailto:csv-viewer-online@tianon.anonaddy.me).
+
+Visit counts are collected with self-hosted [Umami](https://umami.is/). It
+records the page visited, never your file or its contents.

--- a/tests/serve.mjs
+++ b/tests/serve.mjs
@@ -5,7 +5,9 @@ import { readFile } from 'node:fs/promises'
 import { extname, join, normalize } from 'node:path'
 
 const ROOT = new URL('..', import.meta.url).pathname
-const PORT = Number(process.env.PORT || 4173)
+// Matches playwright.config.mjs, and deliberately not a common dev-server
+// default (3000/4173/5173/8080) — sharing one risks talking to another project.
+const PORT = Number(process.env.PORT || 4319)
 
 const TYPES = {
   '.html': 'text/html; charset=utf-8',


### PR DESCRIPTION
The README still described a viewer with two dependencies:

```md
# CSV Viewer Online
### Used plugins:
- PapaParse for parsing CSV
- handsontable for showing the parsed data as a spreadsheet
```

Since then the tool gained editing, export, encoding detection, parse reporting, a test suite and CI, and was renamed in #42.

## What the new one covers

- **What it does** — separators, encodings (including the Windows-1252 case Excel produces), quoted fields, sorting, search, editing, download, and honest parse reporting. Written to match the site's own copy rather than drift from it.
- **How it is built** — three files, no build step, and *why* the grid and parser are fetched on first file open: Handsontable alone is ~1.6 MB, 92% of the old page weight, wasted on every visit where nobody opened a file.
- **Development** — how to serve it, how to run the suite, and a table of what each of the six specs covers.
- **Why fixtures are generated rather than committed** — so a fixture that silently stopped being Windows-1252 can't pass while the bug returns.
- **Sponsors** — the $19/month placement and contact address.
- **Analytics** — stated plainly that it records the page visited and never file contents. The site's privacy claim explicitly invites people to open the network panel, so the README shouldn't be coy about the one request they'll see.

## A bug found while documenting

`bun run serve` defaulted to **4173** while `playwright.config.mjs` used **4319**. So the documented command and the tested port disagreed — and 4173 is Vite's preview default, the exact port that once made the suite [silently test an unrelated dev server](https://github.com/csv-viewer-online/csv-viewer-online.github.io/pull/37). Both now default to 4319, with a comment saying why it isn't a common default.

Verified `bun run serve` actually binds there and returns 200 before documenting it.

## Verified

85 tests still pass. Every claim in the README was checked against the repo rather than written from memory — file list, spec list, test count, the `accept` attribute, and the `/` shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)