### PR TITLE
Mark cells you have edited

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,11 +160,46 @@ function applySearch() {
 
   document.body.classList.toggle('no-match', rows.length === 0)
   setCount(rows.length)
-  if (hot && rows.length) hot.loadData(rows)
+  if (hot && rows.length) {
+    gridRows = rows
+    hot.loadData(rows)
+  }
+}
+
+/* Which cells the reader has changed since the file was opened.
+   Keyed by the row object, so a mark stays with its row when the grid is
+   sorted or filtered down to a subset — indices shift, the objects do not.
+
+   The lookup deliberately goes through our own array rather than
+   getSourceDataAtRow, which returns a fresh clone on every call and so can
+   never match anything by identity. */
+let editedCells = new Map()
+let gridRows = []
+
+function rowAt(visualRow) {
+  return gridRows[hot.toPhysicalRow(visualRow)]
+}
+
+function markEdited(visualRow, prop) {
+  const row = rowAt(visualRow)
+  if (!row) return
+  if (!editedCells.has(row)) editedCells.set(row, new Set())
+  editedCells.get(row).add(prop)
+}
+
+/* Applied as a renderer rather than through `cells`, because Handsontable
+   caches cell meta against visual coordinates and does not invalidate it when
+   a sort reorders the rows — the marker would stay behind on whichever row
+   moved into that position. A renderer runs fresh on every draw. */
+function editedRenderer(instance, td, visualRow, column, prop, value, cellProperties) {
+  Handsontable.renderers.TextRenderer.apply(this, arguments)
+  const row = gridRows[instance.toPhysicalRow(visualRow)]
+  td.classList.toggle('is-edited', Boolean(row && editedCells.get(row)?.has(prop)))
 }
 
 function render() {
   if (hot) hot.destroy()
+  gridRows = allRows
   hot = new Handsontable(handsontableContainer, {
     data: allRows,
     colHeaders: fields,
@@ -174,7 +209,21 @@ function render() {
     stretchH: 'all',
     width: '100%',
     height: '100%',
-    licenseKey: 'non-commercial-and-evaluation'
+    licenseKey: 'non-commercial-and-evaluation',
+    renderer: editedRenderer,
+    afterChange(changes, source) {
+      // loadData fires this too, and that is the file arriving, not an edit
+      if (!changes || source === 'loadData' || source === 'updateData') return
+
+      let marked = false
+      for (const [visualRow, prop, oldValue, newValue] of changes) {
+        if (oldValue === newValue) continue
+        markEdited(visualRow, prop)
+        marked = true
+      }
+      // Re-render so the marker appears; this does not fire afterChange again
+      if (marked) hot.render()
+    }
   })
 }
 
@@ -197,6 +246,7 @@ async function loadFile(file, extraWarning) {
     encodingLabel = decoded.encoding === 'UTF-8' ? '' : decoded.encoding
     delimiter = parsed.meta.delimiter || ','
     delimiterLabel = DELIMITER_NAMES[parsed.meta.delimiter] ?? `“${parsed.meta.delimiter}” separated`
+    editedCells = new Map()
     searchInput.value = ''
 
     document.body.classList.remove('loading', 'no-match')

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, edit, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?12">
+  <link rel="stylesheet" href="./styles.css?13">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -222,6 +222,6 @@
     <a class="btn dialog-mail" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">Open in mail app</a>
   </dialog>
 
-  <script src="./app.js?12"></script>
+  <script src="./app.js?13"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -612,6 +612,24 @@ body.no-match .search-empty {
   background-image: none;
 }
 
+/* A cell whose value differs from the file as it was opened. Marked with a
+   corner flag rather than a background tint, so it stays visible while the
+   cell is selected and cannot be mistaken for a value the file contained. */
+.handsontable td.is-edited {
+  position: relative;
+}
+
+.handsontable td.is-edited::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  border: 5px solid transparent;
+  border-top-color: #C7861F;
+  border-right-color: #C7861F;
+  pointer-events: none;
+}
+
 /* Sponsor rail — one uniform frame per tile, so a loud logo can't set the
    tone of the whole page. */
 .rail {

--- a/tests/edits.spec.mjs
+++ b/tests/edits.spec.mjs
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test'
+import { ensureFixtures } from './fixtures.mjs'
+
+let paths
+test.beforeAll(async () => { paths = await ensureFixtures() })
+
+const CELL = (row, col) =>
+  `#handsontable-container .ht_master tbody tr:nth-child(${row}) td:nth-child(${col})`
+
+async function open(page, file = 'plain.csv') {
+  await page.goto('/')
+  await page.setInputFiles('#input-file', paths[file])
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+  await expect(page.locator(CELL(1, 2))).toBeVisible()
+}
+
+/** Sets the editor's value outright — Ctrl+A does not select inside it. */
+async function editCell(page, row, col, value) {
+  await page.dblclick(CELL(row, col))
+  await page.fill('.handsontableInput', value)
+  await page.keyboard.press('Enter')
+}
+
+const marked = (page) => page.$$eval('#handsontable-container .ht_master tbody td.is-edited',
+  tds => tds.map(td => td.textContent))
+
+test('an untouched file has no markers', async ({ page }) => {
+  await open(page)
+  expect(await marked(page)).toEqual([])
+})
+
+test('editing a cell marks it, and only it', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'CHANGED')
+
+  await expect(page.locator(CELL(1, 2))).toHaveClass(/is-edited/)
+  expect(await marked(page)).toEqual(['CHANGED'])
+  // neighbours stay unmarked
+  await expect(page.locator(CELL(1, 3))).not.toHaveClass(/is-edited/)
+  await expect(page.locator(CELL(2, 2))).not.toHaveClass(/is-edited/)
+})
+
+test('emptying a cell with Delete marks it', async ({ page }) => {
+  // The reported case: a wiped cell looked identical to one the file left blank
+  await open(page)
+  await page.click(CELL(1, 2))
+  await page.keyboard.press('Delete')
+
+  await expect(page.locator(CELL(1, 2))).toHaveText('')
+  await expect(page.locator(CELL(1, 2)), 'an emptied cell must not look like file data')
+    .toHaveClass(/is-edited/)
+})
+
+test('retyping the original value still counts as untouched-looking data', async ({ page }) => {
+  // Marking is about "you changed this", so a no-op edit should not mark
+  await open(page)
+  const original = await page.locator(CELL(1, 2)).textContent()
+  await editCell(page, 1, 2, original)
+  await expect(page.locator(CELL(1, 2))).not.toHaveClass(/is-edited/)
+})
+
+test('the marker follows its row when the grid is sorted', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'zzz-last-when-sorted')
+
+  await page.click('#handsontable-container .ht_clone_top thead th:nth-child(2)')
+  await expect(page.locator(CELL(1, 2))).not.toHaveText('zzz-last-when-sorted')
+
+  // Still exactly one marked cell, and it is the one that was edited
+  expect(await marked(page)).toEqual(['zzz-last-when-sorted'])
+})
+
+test('the marker survives searching and clearing', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'Marseille')
+
+  await page.click('#search-input')
+  await page.keyboard.type('Marseille')
+  await expect(page.locator('#handsontable-container .ht_master tbody tr')).toHaveCount(1)
+  expect(await marked(page)).toEqual(['Marseille'])
+
+  for (let i = 0; i < 12; i++) await page.keyboard.press('Backspace')
+  await expect(page.locator('#handsontable-container .ht_master tbody tr')).toHaveCount(3)
+  expect(await marked(page), 'filtering must not lose or duplicate markers').toEqual(['Marseille'])
+})
+
+test('opening another file clears the markers', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'CHANGED')
+  expect(await marked(page)).toHaveLength(1)
+
+  await page.setInputFiles('#input-file', paths['semicolons.csv'])
+  await expect(page.locator('#file-name')).toHaveText('semicolons.csv')
+  expect(await marked(page)).toEqual([])
+})
+
+test('an edited cell still downloads with its new value', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'CHANGED')
+
+  await page.click('#download-btn')
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('[data-export="csv"]')
+  ])
+  const { readFile } = await import('node:fs/promises')
+  const text = await readFile(await download.path(), 'utf8')
+  expect(text).toContain('CHANGED')
+})


### PR DESCRIPTION
Closes #45. Groundwork for #47.

## The problem

A single `Delete` on a selected cell wiped its value with **no sign anything had happened**. An accidentally emptied cell was indistinguishable from one the file left blank — which is exactly how this surfaced: as a report that the app had failed to render a value.

## The fix

Edited cells carry a small amber corner flag. A flag rather than a background tint, so it stays visible while the cell is selected and can't be mistaken for data.

```
│ policy_id │ product │  table    │ record_id │
│ 516106    │ QCPL    │        ◤  │ 1244835   │   ← emptied with Delete
│ 516106    │ QCPL    │ invoices  │ 9999999 ◤ │   ← edited
```

Retyping a value identical to the original does **not** mark, since nothing actually changed. Opening another file clears the marks.

## Two things I got wrong first, both caught by testing

**`getSourceDataAtRow` returns a fresh clone on every call.** Nothing can be tracked by row identity through it:

```js
hot.getSourceDataAtRow(0) === hot.getSourceDataAtRow(0)   // false
```

So the first version marked cells and then never matched them again. Lookups now go through our own array, which Handsontable holds by reference. Marks are keyed on the **row object**, so they follow their row when the grid is sorted or filtered to a subset — indices shift, objects don't.

**Handsontable caches cell meta against visual coordinates** and doesn't invalidate it when a sort reorders rows. Setting a `className` through `cells` left the marker behind on whichever row moved into that position — one edit, two flagged cells after sorting:

```
Expected: ["zzz-last-when-sorted"]
Received: ["Müller", "zzz-last-when-sorted"]
```

A renderer runs fresh on every draw and has neither problem.

## Verified — 93 tests

**8 new**: an untouched file has no markers; editing marks only that cell; `Delete` marks (the reported case); retyping the original doesn't mark; the marker follows its row through sorting; it survives searching and clearing; opening another file clears them; and an edited cell still downloads with its new value.

Cache busters bumped to `?13`.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)