### PR TITLE
Show how many cells are edited, with a way to put them back

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,12 @@ const dropStatus = document.getElementById('drop-status')
 const notice = document.getElementById('notice')
 const noticeText = document.getElementById('notice-text')
 const handsontableContainer = document.getElementById('handsontable-container')
+const editsBadge = document.getElementById('edits')
+const editsCount = document.getElementById('edits-count')
+
+// Handsontable binds undo to the platform's own modifier, so the hint has to
+// match or it sends people looking for a shortcut that does nothing here.
+const UNDO_KEYS = /Mac|iPhone|iPad/.test(navigator.platform || '') ? '\u2318Z' : 'Ctrl+Z'
 
 let hot = null
 let allRows = []
@@ -180,11 +186,36 @@ function rowAt(visualRow) {
   return gridRows[hot.toPhysicalRow(visualRow)]
 }
 
-function markEdited(visualRow, prop) {
+/* Keeps the value the file arrived with, so an edit can be undone in bulk.
+   Only the first change to a cell is recorded — editing twice should revert
+   to the file, not to the intermediate value. */
+function markEdited(visualRow, prop, originalValue) {
   const row = rowAt(visualRow)
   if (!row) return
-  if (!editedCells.has(row)) editedCells.set(row, new Set())
-  editedCells.get(row).add(prop)
+  if (!editedCells.has(row)) editedCells.set(row, new Map())
+  const cells = editedCells.get(row)
+  if (!cells.has(prop)) cells.set(prop, originalValue)
+}
+
+function countEdits() {
+  let n = 0
+  for (const cells of editedCells.values()) n += cells.size
+  return n
+}
+
+function updateEditsIndicator() {
+  const n = countEdits()
+  editsBadge.hidden = n === 0
+  editsCount.textContent = n === 1 ? '1 edited cell' : `${fmt(n)} edited cells`
+}
+
+function revertEdits() {
+  for (const [row, cells] of editedCells) {
+    for (const [prop, originalValue] of cells) row[prop] = originalValue
+  }
+  editedCells = new Map()
+  updateEditsIndicator()
+  if (hot) hot.render()
 }
 
 /* Applied as a renderer rather than through `cells`, because Handsontable
@@ -218,11 +249,13 @@ function render() {
       let marked = false
       for (const [visualRow, prop, oldValue, newValue] of changes) {
         if (oldValue === newValue) continue
-        markEdited(visualRow, prop)
+        markEdited(visualRow, prop, oldValue)
         marked = true
       }
+      if (!marked) return
+      updateEditsIndicator()
       // Re-render so the marker appears; this does not fire afterChange again
-      if (marked) hot.render()
+      hot.render()
     }
   })
 }
@@ -247,6 +280,7 @@ async function loadFile(file, extraWarning) {
     delimiter = parsed.meta.delimiter || ','
     delimiterLabel = DELIMITER_NAMES[parsed.meta.delimiter] ?? `“${parsed.meta.delimiter}” separated`
     editedCells = new Map()
+    updateEditsIndicator()
     searchInput.value = ''
 
     document.body.classList.remove('loading', 'no-match')
@@ -432,6 +466,10 @@ openBtn.onclick = function () {
 }
 
 searchInput.oninput = applySearch
+
+document.getElementById('revert-edits').addEventListener('click', revertEdits)
+// Set once, so the hint names the shortcut that actually works on this machine
+document.getElementById('revert-edits').title = `Put every edited cell back to the file's value. Undo one at a time with ${UNDO_KEYS}.`
 
 window.addEventListener('keydown', (e) => {
   if (e.key === '/' && document.activeElement !== searchInput && document.body.classList.contains('loaded')) {

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, edit, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?13">
+  <link rel="stylesheet" href="./styles.css?14">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -58,6 +58,12 @@
       <span class="count" id="file-count">—</span>
     </span>
     <span class="divider"></span>
+
+    <span class="edits" id="edits" hidden>
+      <span class="edits-dot" aria-hidden="true"></span>
+      <span id="edits-count">0 edited cells</span>
+      <button class="edits-revert" id="revert-edits" type="button">Revert all</button>
+    </span>
 
     <span class="spacer"></span>
 
@@ -222,6 +228,6 @@
     <a class="btn dialog-mail" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">Open in mail app</a>
   </dialog>
 
-  <script src="./app.js?13"></script>
+  <script src="./app.js?14"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -133,6 +133,51 @@ body.loaded .file-chip {
   display: flex;
 }
 
+/* Unsaved-edit indicator. Uses the same amber as the cell corner flags, so
+   the count and the marks read as one thing. */
+.edits {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 0 0 auto;
+  padding: 3px 4px 3px 9px;
+  background: #FFF8E6;
+  border: 1px solid #EBD9A6;
+  border-radius: 999px;
+  font-size: 12px;
+  color: #6B4E10;
+  white-space: nowrap;
+}
+
+.edits[hidden] {
+  display: none;
+}
+
+.edits-dot {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  background: #C7861F;
+  border-radius: 50%;
+}
+
+.edits-revert {
+  padding: 3px 9px;
+  background: var(--canvas);
+  border: 1px solid #EBD9A6;
+  border-radius: 999px;
+  font-family: var(--ui);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: #6B4E10;
+  cursor: pointer;
+}
+
+.edits-revert:hover {
+  background: #FDF1D4;
+  border-color: #C7861F;
+}
+
 .spacer {
   flex: 1 1 auto;
 }
@@ -872,6 +917,15 @@ body.no-match .search-empty {
   body.loaded .mark span,
   body.loaded .divider {
     display: none;
+  }
+
+  /* Keep the dot and the Revert button; the count is what has to give */
+  .edits #edits-count {
+    display: none;
+  }
+
+  .edits {
+    padding-left: 7px;
   }
 
   .search {

--- a/tests/edits-indicator.spec.mjs
+++ b/tests/edits-indicator.spec.mjs
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test'
+import { ensureFixtures } from './fixtures.mjs'
+
+let paths
+test.beforeAll(async () => { paths = await ensureFixtures() })
+
+const CELL = (row, col) =>
+  `#handsontable-container .ht_master tbody tr:nth-child(${row}) td:nth-child(${col})`
+
+async function open(page, file = 'plain.csv') {
+  await page.goto('/')
+  await page.setInputFiles('#input-file', paths[file])
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+  await expect(page.locator(CELL(1, 2))).toBeVisible()
+}
+
+async function editCell(page, row, col, value) {
+  await page.dblclick(CELL(row, col))
+  await page.fill('.handsontableInput', value)
+  await page.keyboard.press('Enter')
+}
+
+test('the indicator stays hidden until something is edited', async ({ page }) => {
+  await open(page)
+  await expect(page.locator('#edits')).toBeHidden()
+})
+
+test('it counts edited cells, and reads naturally at one', async ({ page }) => {
+  await open(page)
+
+  await editCell(page, 1, 2, 'one')
+  await expect(page.locator('#edits')).toBeVisible()
+  await expect(page.locator('#edits-count')).toHaveText('1 edited cell')
+
+  await editCell(page, 2, 2, 'two')
+  await expect(page.locator('#edits-count')).toHaveText('2 edited cells')
+
+  // editing the same cell again is still one edited cell
+  await editCell(page, 2, 2, 'two again')
+  await expect(page.locator('#edits-count')).toHaveText('2 edited cells')
+})
+
+test('the undo hint names the shortcut that works on this platform', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'x')
+
+  const title = await page.getAttribute('#revert-edits', 'title')
+  const expected = process.platform === 'darwin' ? '⌘Z' : 'Ctrl+Z'
+  expect(title, 'the hint must not send people to a shortcut that does nothing here')
+    .toContain(expected)
+})
+
+test.describe('Revert all', () => {
+  test('puts every cell back to the value the file had', async ({ page }) => {
+    await open(page)
+    const before = await Promise.all([
+      page.locator(CELL(1, 2)).textContent(),
+      page.locator(CELL(2, 3)).textContent()
+    ])
+
+    await editCell(page, 1, 2, 'CHANGED')
+    await page.click(CELL(2, 3))
+    await page.keyboard.press('Delete')
+    await expect(page.locator('#edits-count')).toHaveText('2 edited cells')
+
+    await page.click('#revert-edits')
+
+    await expect(page.locator(CELL(1, 2))).toHaveText(before[0])
+    await expect(page.locator(CELL(2, 3))).toHaveText(before[1])
+    await expect(page.locator('#edits')).toBeHidden()
+    expect(await page.locator('#handsontable-container td.is-edited').count()).toBe(0)
+  })
+
+  test('reverts to the file value, not to an intermediate edit', async ({ page }) => {
+    await open(page)
+    const original = await page.locator(CELL(1, 2)).textContent()
+
+    await editCell(page, 1, 2, 'first')
+    await editCell(page, 1, 2, 'second')
+    await page.click('#revert-edits')
+
+    await expect(page.locator(CELL(1, 2))).toHaveText(original)
+  })
+
+  test('reverted values are what then download', async ({ page }) => {
+    await open(page)
+    await editCell(page, 1, 2, 'SHOULD-NOT-SURVIVE')
+    await page.click('#revert-edits')
+
+    await page.click('#download-btn')
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.click('[data-export="csv"]')
+    ])
+    const { readFile } = await import('node:fs/promises')
+    const text = await readFile(await download.path(), 'utf8')
+    expect(text).not.toContain('SHOULD-NOT-SURVIVE')
+    expect(text).toContain('José')
+  })
+})
+
+test('opening another file resets the indicator', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'CHANGED')
+  await expect(page.locator('#edits')).toBeVisible()
+
+  await page.setInputFiles('#input-file', paths['semicolons.csv'])
+  await expect(page.locator('#file-name')).toHaveText('semicolons.csv')
+  await expect(page.locator('#edits')).toBeHidden()
+})
+
+test('the indicator does not break the toolbar at 390px', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await open(page)
+  await editCell(page, 1, 2, 'CHANGED')
+
+  await expect(page.locator('#edits')).toBeVisible()
+  await expect(page.locator('#revert-edits')).toBeVisible()
+  await expect(page.locator('#open-btn')).toBeVisible()
+  expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)).toBe(false)
+  expect(await page.evaluate(() => Math.round(document.querySelector('.toolbar').getBoundingClientRect().height))).toBe(49)
+})


### PR DESCRIPTION
Closes #46.

Undo already worked — it was just invisible. Anyone who wiped a cell by accident had no way to discover the value was one keystroke away, and their likely next move (reloading) would throw away every other edit too.

## What appears

An amber pill in the toolbar, once anything is edited:

```
CSV Viewer & Editor │ qc-like.csv │ 6 rows × 7 cols │ ● 2 edited cells [Revert all]
```

Same amber as the cell corner flags from #48, so the count and the marks read as one thing rather than two unrelated warnings.

## Details worth naming

- **The tooltip names the shortcut for *this* platform** — `⌘Z` on macOS, `Ctrl+Z` elsewhere. Handsontable binds to the platform modifier, so hard-coding one would send half of users to a shortcut that does nothing here. A test asserts the right one.
- **Revert all restores the value each cell had when the file was opened.** Only the *first* change to a cell is recorded, so editing twice and reverting goes back to the file rather than to the intermediate value — tested explicitly.
- **The count is hidden below 820px**, where the dot and the button still fit and the filename needs the room.

## Verified — 101 tests

**8 new**: hidden until something is edited; counts correctly and reads "1 edited cell" at one; re-editing the same cell doesn't double-count; the tooltip names the platform shortcut; Revert all restores values, clears the marks and hides the pill; reverting after two edits returns the *file's* value; reverted values are what then download; opening another file resets it; and the toolbar survives at 390px with no horizontal scroll.

Cache busters bumped to `?14`.

> [!NOTE]
> This also unblocks #47 — warning before the logo discards edits now just needs to check the same state.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)