### PR TITLE
Confirm before the logo throws away unsaved edits

### DIFF
--- a/app.js
+++ b/app.js
@@ -468,6 +468,26 @@ openBtn.onclick = function () {
 searchInput.oninput = applySearch
 
 document.getElementById('revert-edits').addEventListener('click', revertEdits)
+
+/* The wordmark links to /, which reloads and throws away the open file. That
+   was harmless while the grid was read-only; now it is a one-click way to lose
+   work, and it sits exactly where people click to go back. */
+const discardDialog = document.getElementById('discard-dialog')
+
+document.querySelector('a.mark').addEventListener('click', (e) => {
+  const n = countEdits()
+  if (n === 0) return // nothing to lose, let the link behave like a link
+  e.preventDefault()
+  document.getElementById('discard-count').textContent =
+    n === 1 ? '1 edited cell' : `${fmt(n)} edited cells`
+  discardDialog.showModal()
+})
+
+// Escape closes the dialog too, and closing means "keep editing"
+document.getElementById('discard-cancel').addEventListener('click', () => discardDialog.close())
+document.getElementById('discard-confirm').addEventListener('click', () => {
+  window.location.href = '/'
+})
 // Set once, so the hint names the shortcut that actually works on this machine
 document.getElementById('revert-edits').title = `Put every edited cell back to the file's value. Undo one at a time with ${UNDO_KEYS}.`
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, edit, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?14">
+  <link rel="stylesheet" href="./styles.css?15">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -197,6 +197,15 @@
     </a>
   </aside>
 
+  <dialog class="confirm-dialog" id="discard-dialog" aria-labelledby="discard-dialog-title">
+    <h2 id="discard-dialog-title">Discard your edits?</h2>
+    <p>Starting over throws away <strong id="discard-count">your edits</strong>. Your file on disk is untouched either way, but anything you changed here has not been saved anywhere.</p>
+    <div class="confirm-actions">
+      <button class="btn quiet" id="discard-cancel" type="button">Keep editing</button>
+      <button class="btn danger" id="discard-confirm" type="button">Discard and start over</button>
+    </div>
+  </dialog>
+
   <dialog class="sponsor-dialog" id="sponsor-dialog" aria-labelledby="sponsor-dialog-title">
     <button class="dialog-close" id="sponsor-dialog-close" type="button" aria-label="Close">&times;</button>
 
@@ -228,6 +237,6 @@
     <a class="btn dialog-mail" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">Open in mail app</a>
   </dialog>
 
-  <script src="./app.js?14"></script>
+  <script src="./app.js?15"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -760,7 +760,8 @@ body.no-match .search-empty {
 
 /* Sponsor enquiry dialog. Native <dialog> so focus trapping, Escape and the
    backdrop come from the browser rather than hand-rolled JS. */
-.sponsor-dialog {
+.sponsor-dialog,
+.confirm-dialog {
   width: min(430px, calc(100vw - 32px));
   padding: 26px 26px 24px;
   border: 1px solid var(--border);
@@ -770,7 +771,8 @@ body.no-match .search-empty {
   font-family: var(--ui);
 }
 
-.sponsor-dialog::backdrop {
+.sponsor-dialog::backdrop,
+.confirm-dialog::backdrop {
   background: rgba(16, 22, 33, 0.42);
 }
 
@@ -795,7 +797,8 @@ body.no-match .search-empty {
   color: var(--ink);
 }
 
-.sponsor-dialog h2 {
+.sponsor-dialog h2,
+.confirm-dialog h2 {
   margin: 0 0 6px;
   font-size: 19px;
   font-weight: 700;
@@ -994,4 +997,30 @@ body.no-match .search-empty {
   * {
     transition: none !important;
   }
+}
+
+/* Discard confirmation */
+.confirm-dialog p {
+  margin: 0 0 20px;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--prose);
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.confirm-actions .btn {
+  height: 34px;
+}
+
+.btn.danger {
+  background: #B42318;
+}
+
+.btn.danger:hover {
+  background: #97200F;
 }

--- a/tests/discard-guard.spec.mjs
+++ b/tests/discard-guard.spec.mjs
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test'
+import { ensureFixtures } from './fixtures.mjs'
+
+let paths
+test.beforeAll(async () => { paths = await ensureFixtures() })
+
+const CELL = (row, col) =>
+  `#handsontable-container .ht_master tbody tr:nth-child(${row}) td:nth-child(${col})`
+
+async function open(page) {
+  await page.goto('/')
+  await page.setInputFiles('#input-file', paths['plain.csv'])
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+  await expect(page.locator(CELL(1, 2))).toBeVisible()
+}
+
+async function editCell(page, row, col, value) {
+  await page.dblclick(CELL(row, col))
+  await page.fill('.handsontableInput', value)
+  await page.keyboard.press('Enter')
+}
+
+const dialog = (page) => page.locator('#discard-dialog')
+
+test('with nothing edited, the logo just goes home', async ({ page }) => {
+  await open(page)
+  await page.click('a.mark')
+
+  // No prompt for work that does not exist
+  await expect(dialog(page)).toBeHidden()
+  await expect(page.locator('#drop-zone')).toBeVisible()
+  await expect(page.locator('body')).not.toHaveClass(/loaded/)
+})
+
+test('with edits, it asks first and does not navigate', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'CHANGED')
+  await page.click('a.mark')
+
+  await expect(dialog(page)).toBeVisible()
+  // Still on the file — nothing has been thrown away yet
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+  await expect(page.locator(CELL(1, 2))).toHaveText('CHANGED')
+})
+
+test('the prompt says how much is at stake', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'one')
+  await page.click('a.mark')
+  await expect(page.locator('#discard-count')).toHaveText('1 edited cell')
+
+  await page.click('#discard-cancel')
+  await editCell(page, 2, 2, 'two')
+  await page.click('a.mark')
+  await expect(page.locator('#discard-count')).toHaveText('2 edited cells')
+})
+
+test.describe('choosing', () => {
+  test('"Keep editing" returns you to your work untouched', async ({ page }) => {
+    await open(page)
+    await editCell(page, 1, 2, 'CHANGED')
+    await page.click('a.mark')
+    await page.click('#discard-cancel')
+
+    await expect(dialog(page)).toBeHidden()
+    await expect(page.locator('body')).toHaveClass(/loaded/)
+    await expect(page.locator(CELL(1, 2))).toHaveText('CHANGED')
+    await expect(page.locator('#edits-count')).toHaveText('1 edited cell')
+  })
+
+  test('Escape also means keep editing', async ({ page }) => {
+    await open(page)
+    await editCell(page, 1, 2, 'CHANGED')
+    await page.click('a.mark')
+    await page.keyboard.press('Escape')
+
+    await expect(dialog(page)).toBeHidden()
+    await expect(page.locator(CELL(1, 2))).toHaveText('CHANGED')
+  })
+
+  test('"Discard and start over" actually starts over', async ({ page }) => {
+    await open(page)
+    await editCell(page, 1, 2, 'CHANGED')
+    await page.click('a.mark')
+    await page.click('#discard-confirm')
+
+    await expect(page.locator('#drop-zone')).toBeVisible()
+    await expect(page.locator('body')).not.toHaveClass(/loaded/)
+    await expect(page.locator('#edits')).toBeHidden()
+  })
+})
+
+test('reverting removes the reason to warn', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'CHANGED')
+  await page.click('#revert-edits')
+  await expect(page.locator('#edits')).toBeHidden()
+
+  await page.click('a.mark')
+  await expect(dialog(page), 'nothing is unsaved, so no prompt').toBeHidden()
+  await expect(page.locator('#drop-zone')).toBeVisible()
+})


### PR DESCRIPTION
Closes #47. Completes the set with #48 (mark edited cells) and #49 (count them, revert them).

## The problem

The wordmark links to `/`, which reloads and discards the open file. Harmless while the grid was read-only — but since editing shipped it's a one-click way to lose work, and it sits exactly where people click to go back.

## What happens now

```
┌──────────────────────────────────────────────────┐
│  Discard your edits?                             │
│                                                  │
│  Starting over throws away 2 edited cells. Your  │
│  file on disk is untouched either way, but       │
│  anything you changed here has not been saved    │
│  anywhere.                                       │
│                                                  │
│            [ Keep editing ]  [ Discard and start over ]
└──────────────────────────────────────────────────┘
```

It names **how much** is at stake, and says plainly that the file on disk is fine — that's the thing people actually worry about in the moment.

## The safe choice is the default, in both directions

- **Keep editing** takes focus when the dialog opens (verified: `focused button: discard-cancel`)
- **Escape** maps to keep editing, not discard
- With **nothing edited** the link behaves like a link — no nagging about work that doesn't exist
- **Reverting** removes the reason to warn, so it doesn't prompt afterwards either

## Verified — 108 tests

**7 new**: no prompt with nothing edited; prompt appears with edits *and does not navigate*; the count is right at one and at two; Keep editing leaves the work and the edit count untouched; Escape does the same; Discard actually starts over and clears the indicator; and reverting first means no prompt.

Reuses the dialog chrome from the sponsor dialog rather than a second implementation, and native `<dialog>` again for focus trapping and Escape.

## Deliberately not included

A `beforeunload` handler for tab closes and reloads. Browsers show a generic, unstylable message there and it's easy to make annoying. The logo is the case worth guarding first because **the app itself causes it** — a tab close is the user's own intent.

Cache busters bumped to `?15`.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)