### PR TITLE
Clear the edit marker when a cell goes back to the file's value

### DIFF
--- a/app.js
+++ b/app.js
@@ -186,15 +186,31 @@ function rowAt(visualRow) {
   return gridRows[hot.toPhysicalRow(visualRow)]
 }
 
-/* Keeps the value the file arrived with, so an edit can be undone in bulk.
-   Only the first change to a cell is recorded — editing twice should revert
-   to the file, not to the intermediate value. */
-function markEdited(visualRow, prop, originalValue) {
+/* Handsontable hands back '' for a cleared cell and null for an absent one,
+   so compare loosely — otherwise undoing a Delete looks like a new value. */
+const sameValue = (a, b) => (a == null ? '' : String(a)) === (b == null ? '' : String(b))
+
+/* Records the value the file arrived with, so an edit can be undone in bulk,
+   and drops the record once a cell is back to that value — by undo, or by
+   simply retyping it. Without the second half a cell stays flagged as edited
+   while showing exactly what the file contained. */
+function noteChange(visualRow, prop, oldValue, newValue) {
   const row = rowAt(visualRow)
   if (!row) return
-  if (!editedCells.has(row)) editedCells.set(row, new Map())
   const cells = editedCells.get(row)
-  if (!cells.has(prop)) cells.set(prop, originalValue)
+
+  if (cells?.has(prop)) {
+    if (sameValue(newValue, cells.get(prop))) {
+      cells.delete(prop)
+      if (cells.size === 0) editedCells.delete(row)
+    }
+    return
+  }
+
+  // Only the first change to a cell is recorded, so reverting goes back to the
+  // file rather than to an intermediate value.
+  if (sameValue(oldValue, newValue)) return
+  editedCells.set(row, (cells ?? new Map()).set(prop, oldValue))
 }
 
 function countEdits() {
@@ -246,15 +262,12 @@ function render() {
       // loadData fires this too, and that is the file arriving, not an edit
       if (!changes || source === 'loadData' || source === 'updateData') return
 
-      let marked = false
       for (const [visualRow, prop, oldValue, newValue] of changes) {
-        if (oldValue === newValue) continue
-        markEdited(visualRow, prop, oldValue)
-        marked = true
+        noteChange(visualRow, prop, oldValue, newValue)
       }
-      if (!marked) return
       updateEditsIndicator()
-      // Re-render so the marker appears; this does not fire afterChange again
+      // Re-render so markers appear and disappear; this does not fire
+      // afterChange again
       hot.render()
     }
   })

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, edit, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?15">
+  <link rel="stylesheet" href="./styles.css?16">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -237,6 +237,6 @@
     <a class="btn dialog-mail" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">Open in mail app</a>
   </dialog>
 
-  <script src="./app.js?15"></script>
+  <script src="./app.js?16"></script>
 </body>
 </html>

--- a/tests/edits.spec.mjs
+++ b/tests/edits.spec.mjs
@@ -51,12 +51,56 @@ test('emptying a cell with Delete marks it', async ({ page }) => {
     .toHaveClass(/is-edited/)
 })
 
-test('retyping the original value still counts as untouched-looking data', async ({ page }) => {
-  // Marking is about "you changed this", so a no-op edit should not mark
+test('a no-op edit on an untouched cell does not mark it', async ({ page }) => {
   await open(page)
   const original = await page.locator(CELL(1, 2)).textContent()
   await editCell(page, 1, 2, original)
   await expect(page.locator(CELL(1, 2))).not.toHaveClass(/is-edited/)
+})
+
+// Undo restores the file's value, so the cell is no longer edited. Marking
+// only ever added, so the flag and the count both used to survive an undo.
+const UNDO = process.platform === 'darwin' ? 'Meta+z' : 'Control+z'
+
+test('undo clears the marker and the count', async ({ page }) => {
+  await open(page)
+  const original = await page.locator(CELL(1, 2)).textContent()
+
+  await page.click(CELL(1, 2))
+  await page.keyboard.press('Delete')
+  await expect(page.locator(CELL(1, 2))).toHaveClass(/is-edited/)
+  await expect(page.locator('#edits-count')).toHaveText('1 edited cell')
+
+  await page.keyboard.press(UNDO)
+  await expect(page.locator(CELL(1, 2))).toHaveText(original)
+  await expect(page.locator(CELL(1, 2))).not.toHaveClass(/is-edited/)
+  await expect(page.locator('#edits')).toBeHidden()
+})
+
+test('retyping the original value after an edit clears the marker', async ({ page }) => {
+  await open(page)
+  const original = await page.locator(CELL(1, 2)).textContent()
+
+  await editCell(page, 1, 2, 'CHANGED')
+  await expect(page.locator(CELL(1, 2))).toHaveClass(/is-edited/)
+
+  await editCell(page, 1, 2, original)
+  await expect(page.locator(CELL(1, 2))).not.toHaveClass(/is-edited/)
+  await expect(page.locator('#edits')).toBeHidden()
+})
+
+test('undoing one of two edits leaves the other marked', async ({ page }) => {
+  await open(page)
+  await editCell(page, 1, 2, 'first')
+  await editCell(page, 2, 2, 'second')
+  await expect(page.locator('#edits-count')).toHaveText('2 edited cells')
+
+  await page.click(CELL(2, 2))
+  await page.keyboard.press(UNDO)
+
+  await expect(page.locator('#edits-count')).toHaveText('1 edited cell')
+  await expect(page.locator(CELL(1, 2))).toHaveClass(/is-edited/)
+  await expect(page.locator(CELL(2, 2))).not.toHaveClass(/is-edited/)
 })
 
 test('the marker follows its row when the grid is sorted', async ({ page }) => {


### PR DESCRIPTION
Reported: `⌘Z` restores the value but the amber corner stays, and the toolbar still claims an edit.

## Cause

The tracking added marks and never removed them. A cell that had returned to exactly what the file contained kept claiming to be edited — after an undo, and equally after just retyping the original value:

```
after Delete              value ""      flagged true   1 edited cell
after Cmd+Z               value "Jose"  flagged true   1 edited cell   ← reported
after retyping original   value "Jose"  flagged true   1 edited cell   ← same bug
```

So it was broader than undo: **any** route back to the original left a false marker, and a false count next to it.

## Fix

Every change is compared against the recorded original and the mark dropped when they match. Undo, retyping and **Revert all** now converge on the same state:

```
after Delete              value ""      flagged true    1 edited cell
after Cmd+Z               value "Jose"  flagged false   hidden
after retyping original   value "Jose"  flagged false   hidden
```

The comparison is deliberately loose about `null` vs `''`: Handsontable reports a cleared cell as `''` and an absent one as `null`, so a strict check would treat undoing a `Delete` as a fresh value and re-mark it.

## Why the existing test missed it

There was already a test called *"retyping the original value still counts as untouched-looking data"* — but it only retyped the original on a cell that had **never been edited**, where no mark existed to remove. It passed against the broken code. That's the gap that let this ship, so it's now split into the trivial case plus three real ones:

- undo clears the marker and the count
- retyping the original **after an edit** clears the marker
- undoing one of two edits leaves the other marked, count 2 → 1

**All three fail against the previous code**, verified by stashing the fix:

```
✘ undo clears the marker and the count
✘ retyping the original value after an edit clears the marker
✘ undoing one of two edits leaves the other marked
3 failed
```

## Also checked

`Revert all` mutates rows directly, bypassing Handsontable, so I checked whether its undo stack could resurrect a stale value afterwards. It can't — `⌘Z` after Revert all leaves the file's value in place and no marker.

The undo key in the tests follows `process.platform`, matching how the app picks the modifier.

## Verified — 111 tests

Cache busters bumped to `?16`.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)