### PR TITLE
Make Download a green button with an icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     "description": "View, edit, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?16">
+  <link rel="stylesheet" href="./styles.css?17">
   <!-- The grid and parser are fetched on first file open (see app.js), so
        warm the connection now rather than paying for it then. -->
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
@@ -76,8 +76,13 @@
     </span>
 
     <span class="menu">
-      <button class="btn quiet" id="download-btn" type="button" aria-haspopup="true" aria-expanded="false">
-        Download
+      <button class="btn download" id="download-btn" type="button" aria-label="Download" aria-haspopup="true" aria-expanded="false">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M8 1.9v8"/>
+          <path d="M4.7 6.6 8 9.9l3.3-3.3"/>
+          <path d="M2.6 11.6v1.7a.8.8 0 0 0 .8.8h9.2a.8.8 0 0 0 .8-.8v-1.7"/>
+        </svg>
+        <span class="long">Download</span>
       </button>
       <span class="menu-pop" id="download-menu" role="menu" hidden>
         <button type="button" role="menuitem" data-export="csv">Download as CSV</button>
@@ -237,6 +242,6 @@
     <a class="btn dialog-mail" href="mailto:csv-viewer-online@tianon.anonaddy.me?subject=Advertising on CSV Viewer">Open in mail app</a>
   </dialog>
 
-  <script src="./app.js?16"></script>
+  <script src="./app.js?17"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -255,6 +255,24 @@ body.loaded .search {
   background: #0F5AB8;
 }
 
+/* Green rather than the brand blue, so Download reads as its own action next
+   to Open file instead of competing with it. #0B7A3E clears 4.5:1 against
+   white text; the lighter greens that looked nicer did not. */
+.btn.download {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: #0B7A3E;
+}
+
+.btn.download:hover {
+  background: #096632;
+}
+
+.btn.download svg {
+  flex: 0 0 auto;
+}
+
 .btn.quiet {
   background: var(--canvas);
   color: var(--ink);

--- a/tests/download-button.spec.mjs
+++ b/tests/download-button.spec.mjs
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test'
+import { ensureFixtures } from './fixtures.mjs'
+
+let paths
+test.beforeAll(async () => { paths = await ensureFixtures() })
+
+async function open(page) {
+  await page.goto('/')
+  await page.setInputFiles('#input-file', paths['plain.csv'])
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+}
+
+/** WCAG relative luminance, for a real contrast check rather than eyeballing. */
+const CONTRAST = `(bg, fg) => {
+  const lum = (rgb) => {
+    const [r, g, b] = rgb.match(/\\d+/g).slice(0, 3).map(Number).map((v) => {
+      const c = v / 255
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+    })
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+  }
+  const a = lum(bg), b2 = lum(fg)
+  return (Math.max(a, b2) + 0.05) / (Math.min(a, b2) + 0.05)
+}`
+
+test('it stands out from Open file rather than matching it', async ({ page }) => {
+  await open(page)
+  const colours = await page.evaluate(() => ({
+    download: getComputedStyle(document.getElementById('download-btn')).backgroundColor,
+    open: getComputedStyle(document.getElementById('open-btn')).backgroundColor
+  }))
+  expect(colours.download).not.toBe(colours.open)
+
+  // green: more green than red or blue
+  const [r, g, b] = colours.download.match(/\d+/g).slice(0, 3).map(Number)
+  expect(g, 'the download button should read as green').toBeGreaterThan(r)
+  expect(g).toBeGreaterThan(b)
+})
+
+test('its label is readable on that green', async ({ page }) => {
+  await open(page)
+  const ratio = await page.evaluate((fn) => {
+    const el = document.getElementById('download-btn')
+    const s = getComputedStyle(el)
+    return eval(`(${fn})`)(s.backgroundColor, s.color)
+  }, CONTRAST)
+  expect(ratio, `contrast was ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5)
+})
+
+test('it carries a download icon', async ({ page }) => {
+  await open(page)
+  const icon = page.locator('#download-btn svg')
+  await expect(icon).toBeVisible()
+  const box = await icon.boundingBox()
+  expect(box.width).toBeGreaterThan(8)
+})
+
+test('it keeps an accessible name even where the text is hidden', async ({ page }) => {
+  for (const width of [1440, 390]) {
+    await page.setViewportSize({ width, height: 844 })
+    await open(page)
+    // the word is hidden below 820px, so the icon must not be a nameless button
+    await expect(page.locator('#download-btn')).toHaveAccessibleName('Download')
+  }
+})
+
+test('it still opens the menu, and the menu still works', async ({ page }) => {
+  await open(page)
+  await page.click('#download-btn')
+  await expect(page.locator('#download-menu')).toBeVisible()
+
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('[data-export="csv"]')
+  ])
+  expect(download.suggestedFilename()).toBe('plain-export.csv')
+})
+
+test('the wider button does not break the toolbar at 390px', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await open(page)
+
+  await expect(page.locator('#download-btn')).toBeVisible()
+  await expect(page.locator('#open-btn')).toBeVisible()
+  expect(await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth)).toBe(false)
+  expect(await page.evaluate(() => Math.round(document.querySelector('.toolbar').getBoundingClientRect().height))).toBe(49)
+})


### PR DESCRIPTION
Download was a quiet outlined button next to a solid blue **Open file**, so the thing most people want once a file is open was the *less* visible of the two.

```
before:  [ Search rows ]  [ Download ]  [ Open file ]      ← outlined, recedes
after:   [ Search rows ]  [⤓ Download]  [ Open file ]      ← solid green
```

## Why green, and why this green

Green rather than a second blue, so it reads as its own action instead of competing with Open file.

`#0B7A3E` specifically: it clears **4.5:1** against white text. The lighter, nicer-looking greens I tried first did not — `#0F8A46` comes out at 4.42:1, which fails at this text size. A test computes the real WCAG ratio from the rendered colours rather than trusting my eye:

```js
expect(ratio, `contrast was ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5)
```

## An accessibility trap this walked into

Below 820px the existing `.btn span.long { display: none }` rule hides the word, collapsing the button to the icon alone — which would have left a **button with no accessible name**. It now carries an explicit `aria-label="Download"`, and a test asserts the name at both 1440 and 390.

## Verified — 117 tests

**6 new**: it differs from Open file and reads as green; label contrast ≥ 4.5:1; the icon renders; accessible name survives at both widths; the menu still opens and still downloads `plain-export.csv`; and the wider button introduces no horizontal scroll at 390px with the toolbar still 49px.

Cache busters bumped to `?17`.

> [!NOTE]
> There are now two solid buttons side by side. If you'd rather have a single clear primary, demoting **Open file** to the quiet outlined style would make Download the obvious action once a file is open — one line, happy to do it if you want it.

> [!NOTE]
> Merging deploys to production, since Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)