### PR TITLE
Deploy the site from Actions instead of the legacy Pages builder

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  # so a stuck or failed deploy can be re-run without an empty commit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel a deploy in flight: a half-published site is worse than a
+# slightly stale one, and cancelling is what left main undeployed before.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/configure-pages@v6
+
+      # The site is plain HTML/CSS/JS, so the checkout is the artifact — no
+      # build step, and no Jekyll pass to strip anything out. node_modules and
+      # the Playwright reports are gitignored, so a fresh checkout omits them.
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: .
+
+      - uses: actions/deploy-pages@v5
+        id: deployment


### PR DESCRIPTION
main has been stale since `1cea7af`. The last three pushes never reached the site.

The legacy branch-based Pages builder errored instantly on each one — `duration: 0`, failing three seconds in, with only the generic `"Page build failed."`:

```
errored  11:51  69ff2f4   Page build failed.
errored  11:44  aa83c6c   Page build failed.
built    11:27  1cea7af   -
errored  10:46  adad1e8   Page build failed.
```

Meanwhile the auto-generated `pages-build-deployment` workflow sat polling `Current status: deployment_queued` for a deployment that never dequeued, and aborted at its ten-minute timeout. Re-running that workflow could not help — its Jekyll build succeeded in 21s every time, so the Actions half was never the part that was failing.

The site is plain HTML/CSS/JS with no `_config.yml` and no underscore-prefixed files, so the legacy builder's Jekyll pass was doing nothing for us and the checkout can be published verbatim. Switching the Pages source to Actions retires that pipeline and puts the deploy somewhere whose logs we can actually read.

`concurrency` deliberately does not cancel in progress: `aa83c6c`'s deploy was cancelled mid-flight by the push after it, which is part of how main drifted this far behind. A slightly stale site beats a half-published one.

The repo setting is already flipped — `build_type` is now `workflow`, so the legacy builder is off and this workflow is what publishes on merge.

## Testing

- Actions pinned to current majors (`checkout@v7`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`) — the old `pages-build-deployment` was warning that its `@v4` actions target deprecated Node 20.
- Verified no underscore-prefixed tracked files, so dropping Jekyll changes nothing that was being served.
- The real check is the merge: it should publish `69ff2f4`'s green Download button, which is not on the live site today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)