### PR TITLE
Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # canary, not latest: the committed bun.lock is lockfileVersion 2, which
       # the current stable (1.3.x) cannot parse. Revisit once 1.4 ships stable.


### PR DESCRIPTION
`actions/checkout@v4` targets Node 20, which GitHub has deprecated. Runs are already being force-migrated to Node 24 with a warning on every one:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

`v7` targets Node 24 natively, so the warning goes away and we stop depending on that fallback staying in place.

Only `checkout` is bumped here. The other pins in `test.yml` are left alone deliberately — `cache@v4` and `upload-artifact@v4` also have newer majors (`v6.1.0` and `v7.0.1`), but those are behaviour-affecting upgrades rather than a runtime bump, and worth doing separately if at all.

## Testing

The workflow is the test suite, so CI on this PR is the verification — a green `playwright` check means checkout still fetches the repo correctly under v7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)