### PR TITLE
Bump actions/cache to v6 and actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo "version=$(bun -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: browser-cache
         with:
           path: ~/.cache/ms-playwright
@@ -40,7 +40,7 @@ jobs:
 
       - run: bun run test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION
Follow-up to #54, clearing the last two actions still targeting Node 20:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/upload-artifact@v4

| Action | Before | After |
|---|---|---|
| `actions/cache` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |

Despite being major bumps, these are runtime and packaging changes rather than behaviour ones — Node 24 support plus a migration to ESM. Nothing about how we call them changes.

Checked for the things that could have bitten us:

- **`if-no-files-found` is unchanged**, still defaulting to `warn`. The upload step currently finds nothing at `playwright-report/`, so it keeps warning rather than starting to fail the build. (That empty path is a real pre-existing issue, but it is not this PR's to fix.)
- **`upload-artifact@v7` adds an opt-in `archive` parameter** for unzipped single-file uploads. We do not set it, so the default zipped behaviour is retained.
- **Both require Actions runner ≥ `2.327.1`.** `ubuntu-latest` satisfies this. Self-hosted runners would need checking first, and we use none.

Expect one cold cache on the Playwright browser download after this merges; the key is unchanged so it repopulates on the first run.

## Testing

The workflow is the test suite, so CI here is the verification. A green `playwright` check exercises all three: checkout, the cache restore/save path, and the artifact upload step. The run's annotations should also come back free of the Node 20 deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)