### PR TITLE
Stop pinning a live cache-buster value in prose

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
 
   <script>
     // Registered inline rather than from app.js so it does not wait on the app
-    // to parse, and so the ?17 version query can never affect whether the
+    // to parse, and so the ?N version query can never affect whether the
     // worker registers.
     if ('serviceWorker' in navigator) {
       addEventListener('load', () => {

--- a/sw.js
+++ b/sw.js
@@ -72,7 +72,7 @@ self.addEventListener('message', (e) => {
 
 const isImmutable = (url) => url.pathname.includes('/vendor/') || url.pathname.includes('/icons/')
 
-// Key on the path alone: index.html asks for styles.css?17 but the precache
+// Key on the path alone: index.html asks for styles.css?N but the precache
 // holds styles.css, and ignoreSearch returns the FIRST match — so an
 // un-normalised put would leave the stale install-time copy winning forever.
 const cacheKey = (request) => {
@@ -100,7 +100,7 @@ async function networkFirst(request) {
     return res
   } catch (err) {
     clearTimeout(timer)
-    // ignoreSearch because index.html requests ./styles.css?17 and ./app.js?17
+    // ignoreSearch because index.html requests ./styles.css?N and ./app.js?N
     // while the cache holds them unqueried.
     const hit = await cache.match(request, { ignoreSearch: true })
     if (hit) return hit

--- a/tests/pwa.spec.mjs
+++ b/tests/pwa.spec.mjs
@@ -91,7 +91,7 @@ test('the shell still loads with the network off', async ({ page, context }) => 
   await context.setOffline(false)
 })
 
-test('the ?17 versioned css and js resolve from cache offline', async ({ page, context }) => {
+test('the version-queried css and js resolve from cache offline', async ({ page, context }) => {
   await page.goto('/')
   await page.evaluate(() => navigator.serviceWorker.ready)
   await page.reload()
@@ -99,7 +99,7 @@ test('the ?17 versioned css and js resolve from cache offline', async ({ page, c
   await context.setOffline(true)
   await page.reload()
 
-  // index.html asks for ./styles.css?17 but the cache holds ./styles.css.
+  // index.html asks for ./styles.css?N but the cache holds ./styles.css.
   // Without ignoreSearch this misses, and the page renders unstyled offline
   // while looking perfectly fine online.
   const applied = await page.evaluate(() => ({
@@ -142,7 +142,7 @@ test('a refreshed shell asset replaces the stale offline copy, not just the onli
   await context.unroute('**/styles.css*')
 
   // Offline reload: the cache must now serve the NEW bytes. If cache.put had
-  // keyed on the queried request (./styles.css?17) instead of the bare path,
+  // keyed on the queried request (./styles.css?N) instead of the bare path,
   // two entries would exist and ignoreSearch's first match — the stale
   // install-time one — would win forever.
   await context.setOffline(true)


### PR DESCRIPTION
Bumping `styles.css` and `app.js` to `?18` in #56 left six comments and one test name still saying `?17`. Grepping `?17` afterwards found six hits and no such asset.

These were not wrong by accident. Each cites the query as a fact about what `index.html` currently requests — a fact that changes every release — and nothing prompts the next person to bump them in step. The same drift will recur at `?19` unless the literal goes.

They now say `?N`. What the comments actually explain is the mechanism: the precache holds bare paths while the page requests queried ones, so lookups need `ignoreSearch` and writes need normalising through `cacheKey`. That does not depend on which number is live today.

| Site | Was |
|---|---|
| `sw.js:75` | `cacheKey` rationale |
| `sw.js:103` | `ignoreSearch` on the network-first fallback |
| `index.html:247` | why the worker registers inline |
| `tests/pwa.spec.mjs:94` | test **name** — now `the version-queried css and js resolve from cache offline` |
| `tests/pwa.spec.mjs:102` | the `ignoreSearch` trap |
| `tests/pwa.spec.mjs:145` | the version-skew regression it guards |

Verified no other pinned version literals remain, and that the live `?18` values in `index.html` are untouched.

## No cache-buster bump

`styles.css` and `app.js` are byte-identical — only comments changed, so there is nothing for a bump to invalidate.

Worth noting: `sw.js` is byte-compared by the browser, so installed clients will fetch a new worker on their next launch and precache the same shell. Harmless, and the no-`skipWaiting` design means it cannot interrupt anyone mid-session.

## Testing

131 passing, unchanged. The renamed test was confirmed to still run and pass under its new name rather than silently disappearing from the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)