### PR TITLE
Drop "Online" from the installed app's name

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "CSV Viewer & Editor Online",
+  "name": "CSV Viewer & Editor",
   "short_name": "CSV Viewer",
   "description": "Open, edit, sort and search CSV files. Nothing is uploaded — your file is parsed on your own device.",
   "start_url": "/",

--- a/tests/branding.spec.mjs
+++ b/tests/branding.spec.mjs
@@ -16,6 +16,14 @@ test('the product is named as a viewer and editor throughout', async ({ page }) 
   expect(ld.name).toBe('CSV Viewer & Editor Online')
   expect(ld.description).toMatch(/edit/i)
 
+  // The installed app is named like the wordmark, not like the page: "Online"
+  // is a search term people type, and it reads as a contradiction under an
+  // icon on an app that runs with no network. Asserted against the wordmark
+  // rather than a literal so the two cannot drift apart.
+  const manifest = await (await page.request.get('/manifest.webmanifest')).json()
+  expect(manifest.name).toBe(await page.locator('.mark span').innerText())
+  expect(manifest.name).not.toMatch(/online/i)
+
   // Editing is described in the prose, not only implied by the UI
   const prose = await page.locator('.content').innerText()
   expect(prose).toMatch(/edit/i)

--- a/tests/pwa.spec.mjs
+++ b/tests/pwa.spec.mjs
@@ -12,7 +12,10 @@ test('the manifest is served, parses, and declares what installation needs', asy
   expect(res.headers()['content-type']).toContain('application/manifest+json')
 
   const m = JSON.parse(await res.text())
-  expect(m.name).toBe('CSV Viewer & Editor Online')
+  // No "Online": this is the label under the installed icon, on an app whose
+  // whole point is working without a network. The page keeps it — see the
+  // naming test in branding.spec.mjs.
+  expect(m.name).toBe('CSV Viewer & Editor')
   expect(m.short_name).toBe('CSV Viewer')
   expect(m.start_url).toBe('/')
   expect(m.scope).toBe('/')


### PR DESCRIPTION
`"name": "CSV Viewer & Editor Online"` is the label under the installed icon, and it contradicts itself there — the app it names is the one that works with no network at all.

## Only the manifest changes

The site was already making this split before this PR. `branding.spec.mjs` has asserted for a while that the toolbar wordmark reads:

```js
await expect(page.locator('.mark span')).toHaveText('CSV Viewer & Editor')
```

No suffix. So there is already an in-product name and a page name, and the manifest simply belongs with the former.

| Surface | Name | Why |
|---|---|---|
| Manifest `name` | **CSV Viewer & Editor** | label under the installed icon |
| Toolbar wordmark | CSV Viewer & Editor | unchanged |
| `<title>`, `h1`, og tags, JSON-LD | CSV Viewer & Editor **Online** | unchanged — `csv viewer online` is what people search for |

`short_name` was already `CSV Viewer` and the description never contained the word, so `name` was the only occurrence in the manifest.

Deliberately **not** touched: the six places the page says "Online". Removing it there would cost the search term the site ranks for, and `smoke.spec.mjs` and `branding.spec.mjs` both guard that wording.

## Testing

The naming test now asserts the manifest name against the wordmark's own text rather than a second hard-coded string, so the two cannot drift apart, and rejects `/online/i` outright so the suffix cannot return under a different spelling.

Verified the guard actually fails: putting `Online` back into the manifest fails `the product is named as a viewer and editor throughout`. 131 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)