### PR TITLE
Explain how it works on the page, and how to install it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,18 @@ afterwards, and no upload request carrying your data.
 
 ## Install it
 
-The site is a PWA. Chrome and Edge offer an install button in the address
-bar; on iOS use Share → Add to Home Screen.
+The site is a PWA, so it installs like an application and then runs with no
+connection at all. Nothing to download from a store, and no account.
+
+| Browser | How |
+| --- | --- |
+| **Chrome, Edge** (desktop) | Click the install icon in the address bar, or pick **Install** from the browser menu |
+| **Chrome** (Android) | Menu → **Add to Home screen** |
+| **Safari** (iOS, iPadOS) | Share → **Add to Home Screen** |
+| **Safari** (macOS 14+) | **File** → **Add to Dock** |
+
+Firefox has no install prompt on desktop; the site works normally in a tab
+there.
 
 Installed, it works with no network at all — the grid and parser are cached
 on first launch. A browser tab deliberately does not preload them, so opening
@@ -18,7 +28,12 @@ the site in a tab stays as light as it has always been; they are still only
 fetched, and cached, once a file is actually opened.
 
 Installed on desktop Chrome or Edge, it also registers as a handler for
-`.csv`, so you can open one straight from Finder or Explorer.
+`.csv`, so you can open one straight from Finder or Explorer. If the OS does
+not offer it, launch the installed app once first — handlers are registered on
+first run.
+
+To uninstall, open the app and use its menu → **Uninstall**, or remove it from
+`chrome://apps`. Uninstalling clears its cached copy of the site.
 
 ## What it does
 

--- a/index.html
+++ b/index.html
@@ -121,13 +121,23 @@
       </div>
 
         <p class="drop-status" id="drop-status" role="status" aria-live="polite"></p>
-        <a class="scroll-cue" href="#about">How it works</a>
+        <a class="scroll-cue" href="#how-it-works">How it works</a>
       </div>
 
       <article class="content" id="about">
         <h2>Read and edit a CSV without handing it to anyone</h2>
         <p>Most online CSV tools ask you to upload your file to a server before you can look at it. A copy of your spreadsheet — customer records, a bank export, whatever it happens to be — then lives on someone else's machine, under their retention policy rather than yours.</p>
         <p>This page does the work in your browser instead. When you pick a file it is read straight from disk by the tab you already have open, parsed in memory, and drawn on screen. There is no account, nothing to delete afterwards, and no upload request carrying your data. You can check that yourself: open your browser's network panel and watch it while you open a file.</p>
+
+        <h2 id="how-it-works">How it works</h2>
+        <ol>
+          <li><strong>You pick a file.</strong> Drop it on the page, or browse for it. Nothing is sent anywhere at this point — the file is simply handed to the tab.</li>
+          <li><strong>It is read and parsed on your device.</strong> The separator and the character encoding are worked out from the bytes themselves, so semicolon exports from Excel and non-UTF-8 files open without a setting to change.</li>
+          <li><strong>The rows are drawn on screen.</strong> Only the rows in view are rendered, which is why a file with tens of thousands of them still scrolls. Sorting, searching and editing all happen in memory.</li>
+          <li><strong>You download what you see.</strong> Your edits, your sort order and only the rows matching your search are written to a new file. The original is never modified.</li>
+        </ol>
+        <p>Because every step happens in the tab, there is no server to trust and no copy of your data to delete afterwards.</p>
+        <p>You can also <strong>install it</strong>. Chrome and Edge show an install button in the address bar; on iPhone and iPad use Share → Add to Home Screen. Installed, the viewer itself is stored on your device, so it opens and reads files with no connection at all — and on desktop it can open a .csv straight from Finder or Explorer.</p>
 
         <h2>What it handles</h2>
         <ul>
@@ -153,7 +163,7 @@
         <p>You can type into cells, and <strong>Download</strong> saves what is on screen as a new CSV or JSON file — including your edits, the sort order you chose, and only the rows matching your search. Your original file is never touched; nothing is written back to it, and closing the tab discards anything you have not downloaded.</p>
 
         <h3>Does it work offline?</h3>
-        <p>Not at the moment. The grid and the CSV parser are fetched from a CDN when the page loads, so the first load needs a connection. Reading your file, once the page is open, does not.</p>
+        <p>Yes, once you install it — see <a href="#how-it-works">How it works</a>. The installed app keeps everything it needs on your device, so it opens and reads files with no connection. In an ordinary browser tab the page itself still has to load first; after that, reading your file needs no network either way.</p>
 
         <h3>What does it cost?</h3>
         <p>Nothing — it is free to use. The sponsor tiles on this page are paid placements.</p>

--- a/styles.css
+++ b/styles.css
@@ -500,7 +500,10 @@ body.load-error .scroll-cue {
   color: var(--prose);
 }
 
-.content ul {
+/* ol as well as ul: the How it works steps are sequential, so they are
+   numbered rather than bulleted, and need the same indent and rhythm. */
+.content ul,
+.content ol {
   margin: 12px 0 0;
   padding-left: 20px;
 }

--- a/tests/pwa.spec.mjs
+++ b/tests/pwa.spec.mjs
@@ -332,3 +332,31 @@ test('a rejecting getFile() from the OS launch is still visible when a file is a
   await expect(page.locator('#notice')).toBeVisible()
   await expect(page.locator('#notice-text')).toHaveText('Could not open that file. It may have been moved or deleted.')
 })
+
+test('the page does not tell readers offline is unsupported', async ({ page }) => {
+  await page.goto('/')
+  const prose = await page.locator('.content').innerText()
+
+  // This is not hypothetical: for several commits after the PWA shipped, the
+  // "Does it work offline?" answer still read "Not at the moment. The grid and
+  // the CSV parser are fetched from a CDN" — prose flatly contradicting the
+  // feature, on the live site, past a full review. Same shape of guard as
+  // export.spec.mjs's "no longer claims there is no export".
+  expect(prose).not.toMatch(/not at the moment/i)
+  expect(prose, 'the libraries are vendored, not on a CDN').not.toMatch(/from a CDN/i)
+  expect(prose, 'the offline answer must point at installing').toMatch(/install/i)
+})
+
+test('the "How it works" cue lands on a heading of that name', async ({ page }) => {
+  await page.goto('/')
+  const cue = page.locator('.scroll-cue')
+  const label = (await cue.innerText()).trim()
+  const href = await cue.getAttribute('href')
+
+  // The cue said "How it works" while pointing at #about, whose first heading
+  // is "Read and edit a CSV without handing it to anyone" — a label promising
+  // a section that did not exist. Assert the destination against the cue's own
+  // text so the two cannot drift apart again.
+  expect(href).toMatch(/^#./)
+  await expect(page.locator(href)).toHaveText(label)
+})


### PR DESCRIPTION
Two additions, plus a live-site correction they turned up.

## `index.html` — a real "How it works" section

The hero already had a cue reading **How it works**, pointing at `#about` — whose first heading is *"Read and edit a CSV without handing it to anyone"*. The label promised a section nobody had written.

There is one now: four numbered steps from picking a file to downloading it, ending with how installing makes it work offline. The cue points at it, so its label matches where it lands.

It deliberately does not re-argue privacy — the section above it already does that. These are the mechanics.

## The offline FAQ was wrong on the live site

This is the part worth a second look. `index.html` has been telling visitors:

> **Does it work offline?**
> *Not at the moment. The grid and the CSV parser are fetched from a CDN when the page loads…*

Both halves untrue since `459978a`: it works offline installed, and the libraries are vendored. It survived a whole-branch review and three follow-up PRs because every one of them looked at code, and nobody read the FAQ describing that code.

## `README.md` — install steps per browser

Was one sentence. The gesture differs on every platform and the address-bar button is easy to miss, so it is now a table.

| Browser | How |
| --- | --- |
| Chrome, Edge (desktop) | install icon in the address bar, or **Install** from the browser menu |
| Chrome (Android) | Menu → **Add to Home screen** |
| Safari (iOS, iPadOS) | Share → **Add to Home Screen** |
| Safari (macOS 14+) | **File** → **Add to Dock** |

Menu paths are named only where they are stable. Chrome moves its install item between versions, so that row says "the browser menu" rather than a path that will age badly. Also documents uninstalling, and the first-run quirk where a file handler is not offered until the app has been launched once.

## Testing

133 passing, two new — both verified to fail against the code they guard:

- **`the page does not tell readers offline is unsupported`** — rejects `not at the moment` and `from a CDN`, and requires the answer to mention installing. Restoring the old FAQ text fails it. Same shape as the existing `the FAQ no longer claims there is no export`.
- **`the "How it works" cue lands on a heading of that name`** — asserts the cue's destination against the cue's own label rather than a literal, so the two cannot drift. Pointing it back at `#about` fails it.

`styles.css` gains `.content ol` alongside `.content ul`, since the steps are numbered. Rendering checked at 1280px: indent, bold lead-ins and rhythm match the existing lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)