### PR TITLE
Stop the worker turning server trouble into broken pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -616,6 +616,11 @@ async function openLaunchedFiles({ files }) {
     if (document.body.classList.contains('loaded')) {
       showNotice('Could not open that file. It may have been moved or deleted.', 'error')
     } else {
+      // loadFile hides the notice before it does anything, so its own catch
+      // never has a stale one to worry about. This path never reaches
+      // loadFile, so it has to clear it here or an unrelated older message
+      // sits above the new error.
+      hideNotice()
       document.body.classList.add('load-error')
       dropStatus.textContent = 'Could not open that file. It may have been moved or deleted.'
     }

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     "description": "View, edit, sort and search CSV files in your browser. Files are parsed locally and never uploaded."
   }
   </script>
-  <link rel="stylesheet" href="./styles.css?18">
+  <link rel="stylesheet" href="./styles.css?19">
   <script defer src="https://analytics.limonte.dev/script.js" data-website-id="980b9c4c-d922-4759-91af-dc5d6a129f57"></script>
 </head>
 
@@ -270,6 +270,6 @@
       })
     }
   </script>
-  <script src="./app.js?18"></script>
+  <script src="./app.js?19"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -57,17 +57,27 @@ self.addEventListener('activate', (e) => {
 // fresh launch rather than mid-session, so it can never reload a page holding
 // unsaved edits.
 
+// addAll always goes to the network — a worker's own fetches do not re-enter
+// its fetch handler, so nothing consults the cache on its behalf. Without this
+// check every launch would refetch 1.6 MB on a feature whose whole point is
+// not spending it. Still addAll rather than individual puts, for the subset
+// that is missing: it is atomic, so a warm cut short cannot leave the grid
+// half-cached.
+async function warmVendor() {
+  const cache = await caches.open(CACHE)
+  const missing = []
+  for (const url of VENDOR) {
+    if (!(await cache.match(url, { ignoreSearch: true }))) missing.push(url)
+  }
+  if (missing.length) await cache.addAll(missing)
+}
+
 // Only an installed client asks for this. Failures are swallowed on purpose:
 // a warm that does not finish leaves the app exactly as capable as a browser
 // tab, which is the status quo rather than a regression.
 self.addEventListener('message', (e) => {
   if (!e.data || e.data.type !== 'warm-vendor') return
-  e.waitUntil(
-    caches
-      .open(CACHE)
-      .then((c) => c.addAll(VENDOR))
-      .catch(() => {})
-  )
+  e.waitUntil(warmVendor().catch(() => {}))
 })
 
 const isImmutable = (url) => url.pathname.includes('/vendor/') || url.pathname.includes('/icons/')
@@ -91,19 +101,36 @@ async function cacheFirst(request) {
 
 async function networkFirst(request) {
   const cache = await caches.open(CACHE)
+  // Looked up before the fetch rather than in the catch, because whether a
+  // usable fallback exists is what decides if it is safe to put a deadline on
+  // the network at all. ignoreSearch because index.html requests
+  // ./styles.css?N and ./app.js?N while the cache holds them unqueried.
+  const cached = await cache.match(request, { ignoreSearch: true })
+
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), NETWORK_TIMEOUT)
+  // Race the network only when there is something to fall back to. Anything
+  // same-origin and not precached comes through here on its first request —
+  // og.png, a sponsor logo — and aborting those at 3s would turn a slow load
+  // into a broken image, where before this worker existed they merely arrived
+  // late. With a copy in hand the deadline is worth it; without one it is
+  // strictly worse than waiting.
+  const timer = cached ? setTimeout(() => controller.abort(), NETWORK_TIMEOUT) : null
+
   try {
-    const res = await fetch(request, { signal: controller.signal })
-    clearTimeout(timer)
-    if (res.ok) await cache.put(cacheKey(request), res.clone())
-    return res
+    const res = await fetch(request, cached ? { signal: controller.signal } : undefined)
+    if (timer) clearTimeout(timer)
+    if (res.ok) {
+      await cache.put(cacheKey(request), res.clone())
+      return res
+    }
+    // A 5xx, or a 404 caught mid-deploy, would otherwise be handed to the page
+    // as its own stylesheet or script and break it — while a copy known to
+    // work sits in the cache. With nothing cached there is nothing better to
+    // offer, so the real response goes through and the browser reports it.
+    return cached || res
   } catch (err) {
-    clearTimeout(timer)
-    // ignoreSearch because index.html requests ./styles.css?N and ./app.js?N
-    // while the cache holds them unqueried.
-    const hit = await cache.match(request, { ignoreSearch: true })
-    if (hit) return hit
+    if (timer) clearTimeout(timer)
+    if (cached) return cached
     throw err
   }
 }

--- a/tests/pwa.spec.mjs
+++ b/tests/pwa.spec.mjs
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test'
 import { ensureFixtures } from './fixtures.mjs'
 
+// Mirrors NETWORK_TIMEOUT in sw.js; tests here need to out-wait it.
+const NETWORK_TIMEOUT_MS = 3000
+
 let paths
 test.beforeAll(async () => { paths = await ensureFixtures() })
 
@@ -359,4 +362,71 @@ test('the "How it works" cue lands on a heading of that name', async ({ page }) 
   // text so the two cannot drift apart again.
   expect(href).toMatch(/^#./)
   await expect(page.locator(href)).toHaveText(label)
+})
+
+test('a failing server does not break the app when a good copy is cached', async ({ page, context }) => {
+  await page.goto('/')
+  await page.evaluate(() => navigator.serviceWorker.ready)
+  await page.reload()
+
+  // A 5xx, or a 404 caught mid-deploy, used to be handed straight to the page
+  // as its own script: app.js fails to load and nothing works, while a copy
+  // known to be good sits in the cache unused.
+  await context.route('**/app.js*', (route) =>
+    route.fulfill({ status: 500, contentType: 'text/javascript', body: '/* deploying */' }))
+  await page.reload()
+  await context.unroute('**/app.js*')
+
+  // If app.js came from cache the app is alive, so opening a file still works.
+  await page.setInputFiles('#input-file', paths['plain.csv'])
+  await expect(page.locator('body')).toHaveClass(/loaded/)
+  await expect(page.locator('#handsontable-container .ht_master tbody tr')).toHaveCount(3)
+})
+
+test('a slow asset with nothing cached is waited for, not aborted', async ({ page, context }) => {
+  await page.goto('/')
+  await page.evaluate(() => navigator.serviceWorker.ready)
+  await page.reload()
+
+  // Same-origin and never precached, so it comes through networkFirst with no
+  // fallback. Arming the 3s abort here would turn a slow load into a failed
+  // one — a broken sponsor logo on exactly the connections least able to
+  // afford a retry.
+  await context.route('**/slow-probe.png', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, NETWORK_TIMEOUT_MS + 1000))
+    await route.fulfill({ status: 200, contentType: 'image/png', body: 'not-really-a-png' })
+  })
+
+  const ok = await page.evaluate(() => fetch('/slow-probe.png').then((r) => r.ok, () => false))
+  expect(ok, 'a slow uncached asset must still arrive').toBe(true)
+  await context.unroute('**/slow-probe.png')
+})
+
+test('warming again does not refetch what is already cached', async ({ page, context }) => {
+  const grid = []
+  // context, not page: a worker's own fetches are invisible to a page listener.
+  context.on('request', (r) => { if (/handsontable/.test(r.url())) grid.push(r.url()) })
+
+  const warm = () => page.evaluate(async () => {
+    const reg = await navigator.serviceWorker.ready
+    reg.active.postMessage({ type: 'warm-vendor' })
+  })
+
+  await page.goto('/')
+  await warm()
+  await expect.poll(async () =>
+    page.evaluate(async () => {
+      const c = await caches.open('csv-viewer-v1')
+      return !!(await c.match('./vendor/handsontable.full.min.js', { ignoreSearch: true }))
+    }), { timeout: 30_000 }
+  ).toBe(true)
+
+  const afterFirst = grid.length
+  expect(afterFirst, 'the first warm must actually fetch the grid').toBeGreaterThan(0)
+
+  // Asserting an absence, so some wait is unavoidable — this is not covering
+  // for flakiness. addAll used to refetch all three unconditionally.
+  await warm()
+  await page.waitForTimeout(1500)
+  expect(grid.length, 'a second warm must not refetch 1.6 MB').toBe(afterFirst)
 })


### PR DESCRIPTION
The three actionable `sw.js` items from the final review of #56, each with a test that fails against the previous worker.

## 1. A non-`ok` response was handed to the page

A 5xx, or a 404 caught mid-deploy, arrived as the page's own script or stylesheet and broke it — while a copy known to work sat unused in the cache. It now prefers the cached copy, and only passes the failure through when there is nothing better to offer, so genuine errors are still reported on a cold cache.

The reviewer called this the best value-per-line of the set.

## 2. The 3s deadline applied to requests with no fallback

Anything same-origin and not precached comes through `networkFirst` on its **first** request — `og.png`, a sponsor logo. Aborting those at 3s turned a late image into a broken one, which is worse than the behaviour before the worker existed.

The deadline is now armed only when a cached copy exists to fall back to. As a side effect the cache lookup moved from the error path to the top, so it happens once either way.

## 3. Warming re-fetched all of `vendor/` every launch

`addAll` always goes to the network, and a worker's own fetches do not re-enter its `fetch` handler, so nothing consulted the cache on its behalf — 1.6 MB per launch, on a feature whose entire point is not spending it. It now adds only what is missing, still via `addAll` so a warm cut short cannot leave the grid half-cached.

## Deliberately not changed

`cacheFirst` still has no deadline. I listed this as a fourth item in an earlier summary, which was my error — the review's own triage argued the asymmetry is *correct*, and it is right: aborting a cold 1.6 MB grid fetch at 3s would fail exactly the connections least able to retry.

Also included, from the same review's minor list: the launch-error path now clears a stale notice that could otherwise sit above the new message. `loadFile` hides the notice before doing anything, so its own catch never had this problem; this path never reaches `loadFile`.

## Testing

136 passing, three new, each verified **failing against the old `sw.js` and passing against the new one** in the same run:

| Test | Fails before because |
|---|---|
| `a failing server does not break the app when a good copy is cached` | the 500 body reaches the page, `app.js` never runs, opening a file does nothing |
| `a slow asset with nothing cached is waited for, not aborted` | the fetch is aborted at 3s and rejects |
| `warming again does not refetch what is already cached` | the second warm issues three more grid requests |

The last one watches `context.on('request')` rather than `page.on` — a worker's own fetches are invisible to a page listener, which is a trap this project has already been caught by twice.

Suite run twice to check the timing-sensitive ones don't flake. `?19` because `app.js` changed, in step per the convention — a stale query is what lets an old copy overwrite a fresh cache entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)