### PR TITLE
Close out the PWA leftovers, and stop the docs drifting again

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ connection at all. Nothing to download from a store, and no account.
 
 | Browser | How |
 | --- | --- |
-| **Chrome, Edge** (desktop) | Click the install icon in the address bar, or pick **Install** from the browser menu |
+| **Chrome, Edge, Brave** (desktop) | Click the install icon in the address bar, or pick **Install** from the browser menu |
 | **Chrome** (Android) | Menu → **Add to Home screen** |
 | **Safari** (iOS, iPadOS) | Share → **Add to Home Screen** |
 | **Safari** (macOS 14+) | **File** → **Add to Dock** |
@@ -27,13 +27,18 @@ on first launch. A browser tab deliberately does not preload them, so opening
 the site in a tab stays as light as it has always been; they are still only
 fetched, and cached, once a file is actually opened.
 
-Installed on desktop Chrome or Edge, it also registers as a handler for
-`.csv`, so you can open one straight from Finder or Explorer. If the OS does
-not offer it, launch the installed app once first — handlers are registered on
-first run.
+Installed on a desktop Chromium browser, it also registers as a handler for
+`.csv`, so you can open one straight from Finder or Explorer. It will not
+become the *default* for CSV files — Numbers and Excel keep that — so use
+**Open With** unless you change the default yourself. If the app is not
+offered at all, launch it once first; handlers are registered on first run.
+
+An OS launch always opens a new window, so double-clicking a file can never
+replace one you have open with unsaved edits.
 
 To uninstall, open the app and use its menu → **Uninstall**, or remove it from
-`chrome://apps`. Uninstalling clears its cached copy of the site.
+`chrome://apps`. Chrome offers to delete the app's stored data at the same
+time; leave that unticked and the cached copy of the site stays behind.
 
 ## What it does
 
@@ -61,14 +66,15 @@ and `.txt` are offered in the picker, and any dropped file is attempted.
 
 ## How it is built
 
-Plain HTML, CSS and JavaScript with **no build step**. The whole site is four
-files plus static assets:
+Plain HTML, CSS and JavaScript with **no build step**. The whole site is five
+hand-written files plus static assets:
 
 ```
-index.html      markup and <head>
-styles.css      all styling
-app.js          parsing, the grid, search, export
-sw.js           service worker: caches the shell, warms vendor/ when installed
+index.html            markup and <head>
+styles.css            all styling
+app.js                parsing, the grid, search, export
+sw.js                 service worker: caches the shell, warms vendor/ when installed
+manifest.webmanifest  install metadata, icons, .csv file handling
 ```
 
 Two libraries do the heavy lifting, vendored into `vendor/` rather than
@@ -106,7 +112,7 @@ drag-and-drop, the clipboard, grid rendering.
 ```sh
 bun install
 bunx playwright install chromium
-bun run test          # 130 tests
+bun run test
 bun run test:headed   # watch them run
 bun run test:ui       # interactive
 ```

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
         <ul>
           <li><strong>Commas, semicolons, tabs and pipes.</strong> The separator is detected automatically, so European semicolon exports and tab-separated files open without changing a setting.</li>
           <li><strong>Quoted fields.</strong> Values wrapped in quotes can contain commas, escaped quotes and line breaks.</li>
-          <li><strong>UTF-8 text.</strong> Accented characters and non-Latin scripts render as written.</li>
+          <li><strong>UTF-8, UTF-16 and Windows-1252.</strong> The encoding is detected from the bytes, so accented characters survive — including from Excel's default CSV export, which is not UTF-8. A file that is not UTF-8 says which encoding was found, so a wrong guess is visible rather than silent.</li>
           <li><strong>Sorting.</strong> Click a column header to sort by that column.</li>
           <li><strong>Column widths.</strong> Drag the edge of a header to resize it.</li>
           <li><strong>Search.</strong> Filter to matching rows across every column; press <kbd>/</kbd> to jump to the search box.</li>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -14,5 +14,6 @@
   ],
   "file_handlers": [
     { "action": "/", "accept": { "text/csv": [".csv"] } }
-  ]
+  ],
+  "launch_handler": { "client_mode": "navigate-new" }
 }

--- a/tests/pwa.spec.mjs
+++ b/tests/pwa.spec.mjs
@@ -430,3 +430,15 @@ test('warming again does not refetch what is already cached', async ({ page, con
   await page.waitForTimeout(1500)
   expect(grid.length, 'a second warm must not refetch 1.6 MB').toBe(afterFirst)
 })
+
+test('an OS launch opens its own window rather than reusing one', async ({ request }) => {
+  const m = await (await request.get('/manifest.webmanifest')).json()
+
+  // navigate-new is load-bearing, not a default worth tidying away. The launch
+  // consumer hands its file straight to loadFile, and the discard guard is
+  // wired only to the wordmark — so reusing an existing window would replace
+  // whatever the reader had open, unsaved edits and all, without asking.
+  // A fresh window cannot do that. Changing this to focus-existing or
+  // navigate-existing means adding that guard first.
+  expect(m.launch_handler.client_mode).toBe('navigate-new')
+})

--- a/tests/smoke.spec.mjs
+++ b/tests/smoke.spec.mjs
@@ -275,3 +275,16 @@ test.describe('head and static files', () => {
     expect(await res.text()).toContain('<svg')
   })
 })
+
+test('every spec file appears in the README table', async () => {
+  // That table drifted to six rows out of eleven before anyone noticed, and the
+  // test count beside it went stale three separate times. The count is gone;
+  // this keeps the table honest without anyone having to remember.
+  const { readdir, readFile } = await import('node:fs/promises')
+  const here = new URL('.', import.meta.url)
+  const specs = (await readdir(here)).filter((f) => f.endsWith('.spec.mjs')).sort()
+  const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8')
+
+  const missing = specs.filter((f) => !readme.includes('`' + f + '`'))
+  expect(missing, 'these specs have no row in the README Spec table').toEqual([])
+})


### PR DESCRIPTION
The remaining items from #56's review, plus a prose audit that found four wrong claims.

## `launch_handler: navigate-new`

The launch consumer hands its file straight to `loadFile`, and the discard guard is wired only to the wordmark. So under the default launch behaviour, double-clicking a `.csv` could replace whatever you had open — unsaved edits included — without asking.

`navigate-new` makes that unreachable, rather than requiring a confirmation the drop and browse paths deliberately do not have either. A test asserts it with the reasoning attached, so it does not get "tidied" to `focus-existing` later.

## Prose audit

| Claim | Reality |
|---|---|
| `# 130 tests` in the README | 136. Third time it has gone stale |
| Uninstalling "clears its cached copy" | Chrome offers it as a checkbox; unticked, the data stays |
| "the whole site is **four** files" | five — `manifest.webmanifest` is hand-written source, not an asset |
| index.html: "**UTF-8 text.** Accented characters…" | `decodeFile` has always handled UTF-16 both endiannesses and Windows-1252 — which is what Excel's default CSV export produces |

That last one was underselling the feature most likely to make someone stay, and contradicted both the README and the "How it works" section directly above it.

The test count is **removed** rather than corrected — a number nothing verifies will drift again. The Spec table had lost rows before too, so a test now checks every spec file has one; removing a row fails it.

## iOS: my earlier warning was wrong

I flagged several times that Apple's seven-day storage eviction made the README's offline claim optimistic. It does not: the seven-day cap applies to Safari's *browsing* context, while home screen web apps keep their own days-of-use counter and their first-party data is not expected to be deleted. The claim stands as written, and nothing needed changing.

## Finder double-click: verified as far as it can be

I could not automate an OS double-click, but the installed app on this machine gave me the plumbing to inspect. The bundle declares the document type, and Launch Services claims the CSV UTI:

```
CFBundleTypeExtensions => [ "csv" ]
CFBundleTypeMIMETypes  => [ "text/csv" ]
claimed UTIs:            public.comma-separated-values-text
```

So registration works. It will not be the *default* handler — Numbers and Excel hold that — which the README now says, since "double-click does nothing" would otherwise look like a bug.

Incidentally this confirmed #58 reaching a live install: Launch Services reports the display name as `CSV Viewer & Editor` while the bundle's baked-in `CFBundleName` is still `CSV Viewer & Editor Online`. Brave picked up the rename from the refreshed manifest, and is now listed in the install table.

## Testing

138 passing. Both new tests verified to fail against what they guard. No cache-buster bump: `app.js` and `styles.css` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)