### PR TITLE
Keep CLAUDE.md out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ playwright-report/
 blob-report/
 .DS_Store
 *.swp
+CLAUDE.md


### PR DESCRIPTION
Pages serves the repo root, so a committed `CLAUDE.md` would be readable at `/CLAUDE.md` — the same way `docs/superpowers/` was before #59 removed it.

Nothing in it is secret today: both payment links are public by design. But it is the file that accumulates rates, payment details and notes about advertisers, and none of that belongs on a public URL. Ignoring it keeps it local, where Claude still reads it — `.gitignore` affects git, not what gets loaded from disk.

One line:

```diff
  .DS_Store
  *.swp
+ CLAUDE.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)